### PR TITLE
Fix broken strings command

### DIFF
--- a/swiftgen-cli/strings.swift
+++ b/swiftgen-cli/strings.swift
@@ -19,7 +19,7 @@ let stringsCommand = command(
   do {
     try parser.parseStringsFile(String(path))
     
-    let templateRealPath = try findTemplate("colors", templateShortName: templateName, templateFullPath: templatePath)
+    let templateRealPath = try findTemplate("strings", templateShortName: templateName, templateFullPath: templatePath)
     let template = try GenumTemplate(path: templateRealPath)
     let context = parser.stencilContext(enumName: enumName)
     let rendered = try template.render(context)


### PR DESCRIPTION
The "strings" command was attempting to generate colors instead.

(I haven't tested this so I don't know if any other changes are needed.)