### PR TITLE
Unnest Scene and Segue structs to work around a LLVM bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ---
 
+## 0.7.3
+
+#### Fixes
+
+* Restructured storyboard templates to work around an LLVM issue with nested types.
+
+> Scenes and Segues are now referenced via `StoryboardScene.<Storyboard>` and `StoryboardSegue.<Storyboard>.<Segue>`
+
 ## 0.7.2
 
 #### Enhancements

--- a/GenumKit/GenumKit.podspec
+++ b/GenumKit/GenumKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "GenumKit"
-  s.version      = "0.7.2"
+  s.version      = "0.7.3"
   s.summary      = "A tool to build constants using enums for your UIImage, Storyboards, Assets, Colors, and more"
 
   s.description  = <<-DESC

--- a/GenumKit/Stencil/Contexts.swift
+++ b/GenumKit/Stencil/Contexts.swift
@@ -72,7 +72,7 @@ extension AssetsCatalogParser {
        - `class`: `String` (absent if generic UIStoryboardSegue)
 */
 extension StoryboardParser {
-  public func stencilContext(sceneEnumName sceneEnumName: String = "Scene", segueEnumName: String = "Segue") -> Context {
+  public func stencilContext(sceneEnumName sceneEnumName: String = "StoryboardScene", segueEnumName: String = "StoryboardSegue") -> Context {
     let storyboards = Set(storyboardsScenes.keys).union(storyboardsSegues.keys).sort(<)
     let storyboardsMap = storyboards.map { (storyboardName: String) -> [String:AnyObject] in
       var sbMap: [String:AnyObject] = ["name": storyboardName]

--- a/Pods/Target Support Files/GenumKit/Info.plist
+++ b/Pods/Target Support Files/GenumKit/Info.plist
@@ -2,25 +2,25 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>CFBundleDevelopmentRegion</key>
-  <string>en</string>
-  <key>CFBundleExecutable</key>
-  <string>${EXECUTABLE_NAME}</string>
-  <key>CFBundleIdentifier</key>
-  <string>org.cocoapods.${PRODUCT_NAME:rfc1034identifier}</string>
-  <key>CFBundleInfoDictionaryVersion</key>
-  <string>6.0</string>
-  <key>CFBundleName</key>
-  <string>${PRODUCT_NAME}</string>
-  <key>CFBundlePackageType</key>
-  <string>FMWK</string>
-  <key>CFBundleShortVersionString</key>
-  <string>0.7.2</string>
-  <key>CFBundleSignature</key>
-  <string>????</string>
-  <key>CFBundleVersion</key>
-  <string>${CURRENT_PROJECT_VERSION}</string>
-  <key>NSPrincipalClass</key>
-  <string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.cocoapods.${PRODUCT_NAME:rfc1034identifier}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.7.3</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>${CURRENT_PROJECT_VERSION}</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/README.md
+++ b/README.md
@@ -246,42 +246,40 @@ extension UIViewController {
   }
 }
 
-extension UIStoryboard {
-  struct Scene {
-    enum Message : String, StoryboardSceneType {
-      static let storyboardName = "Message"
+struct Scene {
+  enum Message : String, StoryboardSceneType {
+    static let storyboardName = "Message"
 
-      case Composer = "Composer"
-      static func composerViewController() -> UIViewController {
-        return Message.Composer.viewController()
-      }
-
-      case URLChooser = "URLChooser"
-      static func urlChooserViewController() -> XXPickerViewController {
-        return Message.URLChooser.viewController() as! XXPickerViewController
-      }
+    case Composer = "Composer"
+    static func composerViewController() -> UIViewController {
+      return Message.Composer.viewController()
     }
-    enum Wizard : String, StoryboardSceneType {
-      static let storyboardName = "Wizard"
 
-      case CreateAccount = "CreateAccount"
-      static func createAccountViewController() -> CreateAccViewController {
-          return Wizard.CreateAccount.viewController() as! CreateAccViewController
-      }
-
-      case ValidatePassword = "Validate_Password"
-      static func validatePasswordViewController() -> UIViewController {
-          return Wizard.ValidatePassword.viewController()
-      }
+    case URLChooser = "URLChooser"
+    static func urlChooserViewController() -> XXPickerViewController {
+      return Message.URLChooser.viewController() as! XXPickerViewController
     }
   }
+  enum Wizard : String, StoryboardSceneType {
+    static let storyboardName = "Wizard"
 
-  struct Segue {
-    enum Message : String, StoryboardSegueType {
-      case Back = "Back"
-      case Custom = "Custom"
-      case NonCustom = "NonCustom"
+    case CreateAccount = "CreateAccount"
+    static func createAccountViewController() -> CreateAccViewController {
+        return Wizard.CreateAccount.viewController() as! CreateAccViewController
     }
+
+    case ValidatePassword = "Validate_Password"
+    static func validatePasswordViewController() -> UIViewController {
+        return Wizard.ValidatePassword.viewController()
+    }
+  }
+}
+
+struct Segue {
+  enum Message : String, StoryboardSegueType {
+    case Back = "Back"
+    case Custom = "Custom"
+    case NonCustom = "NonCustom"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ extension UIViewController {
   }
 }
 
-struct Scene {
+struct StoryboardScene {
   enum Message : String, StoryboardSceneType {
     static let storyboardName = "Message"
 
@@ -275,7 +275,7 @@ struct Scene {
   }
 }
 
-struct Segue {
+struct StoryboardSegue {
   enum Message : String, StoryboardSegueType {
     case Back = "Back"
     case Custom = "Custom"

--- a/README.md
+++ b/README.md
@@ -215,11 +215,11 @@ This will generate an `enum` for each of your `UIStoryboard`, with one `case` pe
 The generated code will look like this:
 
 ```swift
-protocol StoryboardScene {
+protocol StoryboardSceneType {
     static var storyboardName : String { get }
 }
 
-extension StoryboardScene {
+extension StoryboardSceneType {
     static func storyboard() -> UIStoryboard {
         return UIStoryboard(name: self.storyboardName, bundle: nil)
     }
@@ -229,7 +229,7 @@ extension StoryboardScene {
     }
 }
 
-extension StoryboardScene where Self: RawRepresentable, Self.RawValue == String {
+extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == String {
     func viewController() -> UIViewController {
         return Self.storyboard().instantiateViewControllerWithIdentifier(self.rawValue)
     }
@@ -238,17 +238,17 @@ extension StoryboardScene where Self: RawRepresentable, Self.RawValue == String 
     }
 }
 
-protocol StoryboardSegue : RawRepresentable { }
+protocol StoryboardSegueType : RawRepresentable { }
 
 extension UIViewController {
-  func performSegue<S : StoryboardSegue where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+  func performSegue<S : StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
     performSegueWithIdentifier(segue.rawValue, sender: sender)
   }
 }
 
 extension UIStoryboard {
   struct Scene {
-    enum Message : String, StoryboardScene {
+    enum Message : String, StoryboardSceneType {
       static let storyboardName = "Message"
 
       case Composer = "Composer"
@@ -261,7 +261,7 @@ extension UIStoryboard {
         return Message.URLChooser.viewController() as! XXPickerViewController
       }
     }
-    enum Wizard : String, StoryboardScene {
+    enum Wizard : String, StoryboardSceneType {
       static let storyboardName = "Wizard"
 
       case CreateAccount = "CreateAccount"
@@ -277,7 +277,7 @@ extension UIStoryboard {
   }
 
   struct Segue {
-    enum Message : String, StoryboardSegue {
+    enum Message : String, StoryboardSegueType {
       case Back = "Back"
       case Custom = "Custom"
       case NonCustom = "NonCustom"

--- a/SwiftGen.playground/Pages/Storyboards-Demo.xcplaygroundpage/Contents.swift
+++ b/SwiftGen.playground/Pages/Storyboards-Demo.xcplaygroundpage/Contents.swift
@@ -115,4 +115,6 @@ segues for a specific storyboard.
 //  case .Custom:
 //    // Prepare for your custom segue transition
 //  case .NonCustom:
-//    // Pass in information to the destinatio
+//    // Pass in information to the destination View Controller
+//  }
+//}

--- a/SwiftGen.playground/Pages/Storyboards-Demo.xcplaygroundpage/Contents.swift
+++ b/SwiftGen.playground/Pages/Storyboards-Demo.xcplaygroundpage/Contents.swift
@@ -47,49 +47,47 @@ extension UIViewController {
   }
 }
 
-extension UIStoryboard {
-    struct Scene {
-        enum Wizard : String, StoryboardSceneType {
-            static let storyboardName = "Wizard"
-            
-            case CreateAccount = "CreateAccount"
-            static func createAccountViewController() -> CreateAccViewController {
-                return Wizard.CreateAccount.viewController() as! CreateAccViewController
-            }
-            
-            case AcceptCGU = "Accept-CGU"
-            static func acceptCGUViewController() -> UIViewController {
-                return Wizard.AcceptCGU.viewController()
-            }
-            
-            case ValidatePassword = "Validate_Password"
-            static func validatePasswordViewController() -> UIViewController {
-                return Wizard.ValidatePassword.viewController()
-            }
-            
-            case Preferences = "Preferences"
-            static func preferencesViewController() -> UIViewController {
-                return Wizard.Preferences.viewController()
-            }
+struct StoryboardScene {
+    enum Wizard : String, StoryboardSceneType {
+        static let storyboardName = "Wizard"
+        
+        case CreateAccount = "CreateAccount"
+        static func createAccountViewController() -> CreateAccViewController {
+            return Wizard.CreateAccount.viewController() as! CreateAccViewController
         }
-    }
-    
-  struct Segue {
-        enum Wizard : String, StoryboardSegueType {
-            case Custom = "Custom"
-            case Back = "Back"
-            case NonCustom = "NonCustom"
-            case ShowPassword = "ShowP//: #### Usage Example
-assword"
+        
+        case AcceptCGU = "Accept-CGU"
+        static func acceptCGUViewController() -> UIViewController {
+            return Wizard.AcceptCGU.viewController()
+        }
+        
+        case ValidatePassword = "Validate_Password"
+        static func validatePasswordViewController() -> UIViewController {
+            return Wizard.ValidatePassword.viewController()
+        }
+        
+        case Preferences = "Preferences"
+        static func preferencesViewController() -> UIViewController {
+            return Wizard.Preferences.viewController()
         }
     }
 }
 
+struct StoryboardSegue {
+    enum Wizard : String, StoryboardSegueType {
+        case Custom = "Custom"
+        case Back = "Back"
+        case NonCustom = "NonCustom"
+        case ShowPassword = "ShowPassword"
+    }
+}
 
-let initialVC = UIStoryboard.Scene.Wizard.initialViewController()
+//: #### Usage Example
+
+let initialVC = StoryboardScene.Wizard.initialViewController()
 initialVC.title
 
-let validateVC = UIStoryboard.Scene.Wizard.ValidatePassword.viewController()
+let validateVC = StoryboardScene.Wizard.ValidatePassword.viewController()
 validateVC.title
 
 /* Note: the following line would crash when run in playground, because the storyboard file
@@ -97,7 +95,7 @@ validateVC.title
    not known by the storyboard. But it should work correctly in a real project. */
 // let cgu = UIStoryboard.Scene.Wizard.createAccountViewController()
 
-let segue = UIStoryboard.Segue.Wizard.ShowPassword
+let segue = StoryboardSegue.Wizard.ShowPassword
 initialVC.performSegue(segue)
 
 switch segue {

--- a/SwiftGen.playground/Pages/Storyboards-Demo.xcplaygroundpage/Contents.swift
+++ b/SwiftGen.playground/Pages/Storyboards-Demo.xcplaygroundpage/Contents.swift
@@ -16,11 +16,11 @@ class CreateAccViewController : UIViewController {}
 import Foundation
 import UIKit
 
-protocol StoryboardScene {
+protocol StoryboardSceneType {
     static var storyboardName : String { get }
 }
 
-extension StoryboardScene {
+extension StoryboardSceneType {
     static func storyboard() -> UIStoryboard {
         return UIStoryboard(name: self.storyboardName, bundle: nil)
     }
@@ -30,7 +30,7 @@ extension StoryboardScene {
     }
 }
 
-extension StoryboardScene where Self: RawRepresentable, Self.RawValue == String {
+extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == String {
     func viewController() -> UIViewController {
         return Self.storyboard().instantiateViewControllerWithIdentifier(self.rawValue)
     }
@@ -39,17 +39,17 @@ extension StoryboardScene where Self: RawRepresentable, Self.RawValue == String 
     }
 }
 
-protocol StoryboardSegue : RawRepresentable { }
+protocol StoryboardSegueType : RawRepresentable { }
 
 extension UIViewController {
-  func performSegue<S : StoryboardSegue where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+  func performSegue<S : StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
     performSegueWithIdentifier(segue.rawValue, sender: sender)
   }
 }
 
 extension UIStoryboard {
     struct Scene {
-        enum Wizard : String, StoryboardScene {
+        enum Wizard : String, StoryboardSceneType {
             static let storyboardName = "Wizard"
             
             case CreateAccount = "CreateAccount"
@@ -75,16 +75,16 @@ extension UIStoryboard {
     }
     
   struct Segue {
-        enum Wizard : String, StoryboardSegue {
+        enum Wizard : String, StoryboardSegueType {
             case Custom = "Custom"
             case Back = "Back"
             case NonCustom = "NonCustom"
-            case ShowPassword = "ShowPassword"
+            case ShowPassword = "ShowP//: #### Usage Example
+assword"
         }
     }
 }
 
-//: #### Usage Example
 
 let initialVC = UIStoryboard.Scene.Wizard.initialViewController()
 initialVC.title
@@ -117,6 +117,4 @@ segues for a specific storyboard.
 //  case .Custom:
 //    // Prepare for your custom segue transition
 //  case .NonCustom:
-//    // Pass in information to the destination View Controller
-//  }
-//}
+//    // Pass in information to the destinatio

--- a/SwiftGen.playground/Pages/Storyboards-Demo.xcplaygroundpage/timeline.xctimeline
+++ b/SwiftGen.playground/Pages/Storyboards-Demo.xcplaygroundpage/timeline.xctimeline
@@ -3,22 +3,22 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=2802&amp;EndingColumnNumber=17&amp;EndingLineNumber=90&amp;StartingColumnNumber=1&amp;StartingLineNumber=90&amp;Timestamp=468444495.830892"
+         documentLocation = "#CharacterRangeLen=14&amp;CharacterRangeLoc=2321&amp;EndingColumnNumber=17&amp;EndingLineNumber=85&amp;StartingColumnNumber=1&amp;StartingLineNumber=85&amp;Timestamp=470544891.833411"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=2707&amp;EndingColumnNumber=16&amp;EndingLineNumber=87&amp;StartingColumnNumber=1&amp;StartingLineNumber=87&amp;Timestamp=468444495.831127"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1174&amp;EndingColumnNumber=16&amp;EndingLineNumber=82&amp;StartingColumnNumber=1&amp;StartingLineNumber=82&amp;Timestamp=470544864.341099"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=15&amp;CharacterRangeLoc=2514&amp;EndingColumnNumber=16&amp;EndingLineNumber=81&amp;StartingColumnNumber=1&amp;StartingLineNumber=81&amp;Timestamp=468444495.831296"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1174&amp;EndingColumnNumber=16&amp;EndingLineNumber=76&amp;StartingColumnNumber=1&amp;StartingLineNumber=76&amp;Timestamp=470544864.341273"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=16&amp;CharacterRangeLoc=2608&amp;EndingColumnNumber=17&amp;EndingLineNumber=84&amp;StartingColumnNumber=1&amp;StartingLineNumber=84&amp;Timestamp=468444495.831458"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1174&amp;EndingColumnNumber=17&amp;EndingLineNumber=79&amp;StartingColumnNumber=1&amp;StartingLineNumber=79&amp;Timestamp=470544864.341445"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>

--- a/UnitTests/expected/Storyboards-All-CustomName.swift.out
+++ b/UnitTests/expected/Storyboards-All-CustomName.swift.out
@@ -34,68 +34,66 @@ extension UIViewController {
   }
 }
 
-extension UIStoryboard {
-  struct XCTStoryboardsScene {
-    enum Anonymous : StoryboardScene {
-      static let storyboardName = "Anonymous"
+struct XCTStoryboardsScene {
+  enum Anonymous : StoryboardScene {
+    static let storyboardName = "Anonymous"
+  }
+  enum Message : String, StoryboardScene {
+    static let storyboardName = "Message"
+
+    case Composer = "Composer"
+    static func composerViewController() -> UIViewController {
+      return Message.Composer.viewController()
     }
-    enum Message : String, StoryboardScene {
-      static let storyboardName = "Message"
 
-      case Composer = "Composer"
-      static func composerViewController() -> UIViewController {
-        return Message.Composer.viewController()
-      }
-
-      case MessagesList = "MessagesList"
-      static func messagesListViewController() -> UITableViewController {
-        return Message.MessagesList.viewController() as! UITableViewController
-      }
-
-      case NavCtrl = "NavCtrl"
-      static func navCtrlViewController() -> UINavigationController {
-        return Message.NavCtrl.viewController() as! UINavigationController
-      }
-
-      case URLChooser = "URLChooser"
-      static func urlChooserViewController() -> XXPickerViewController {
-        return Message.URLChooser.viewController() as! XXPickerViewController
-      }
+    case MessagesList = "MessagesList"
+    static func messagesListViewController() -> UITableViewController {
+      return Message.MessagesList.viewController() as! UITableViewController
     }
-    enum Wizard : String, StoryboardScene {
-      static let storyboardName = "Wizard"
 
-      case Accept_CGU = "Accept-CGU"
-      static func acceptCGUViewController() -> UIViewController {
-        return Wizard.Accept_CGU.viewController()
-      }
+    case NavCtrl = "NavCtrl"
+    static func navCtrlViewController() -> UINavigationController {
+      return Message.NavCtrl.viewController() as! UINavigationController
+    }
 
-      case CreateAccount = "CreateAccount"
-      static func createAccountViewController() -> CreateAccViewController {
-        return Wizard.CreateAccount.viewController() as! CreateAccViewController
-      }
-
-      case Preferences = "Preferences"
-      static func preferencesViewController() -> UITableViewController {
-        return Wizard.Preferences.viewController() as! UITableViewController
-      }
-
-      case Validate_Password = "Validate_Password"
-      static func validatePasswordViewController() -> UIViewController {
-        return Wizard.Validate_Password.viewController()
-      }
+    case URLChooser = "URLChooser"
+    static func urlChooserViewController() -> XXPickerViewController {
+      return Message.URLChooser.viewController() as! XXPickerViewController
     }
   }
+  enum Wizard : String, StoryboardScene {
+    static let storyboardName = "Wizard"
 
-  struct XCTStoryboardsSegue {
-    enum Message : String, StoryboardSegue {
-      case CustomBack = "CustomBack"
-      case Embed = "Embed"
-      case NonCustom = "NonCustom"
-      case Show_NavCtrl = "Show-NavCtrl"
+    case Accept_CGU = "Accept-CGU"
+    static func acceptCGUViewController() -> UIViewController {
+      return Wizard.Accept_CGU.viewController()
     }
-    enum Wizard : String, StoryboardSegue {
-      case ShowPassword = "ShowPassword"
+
+    case CreateAccount = "CreateAccount"
+    static func createAccountViewController() -> CreateAccViewController {
+      return Wizard.CreateAccount.viewController() as! CreateAccViewController
     }
+
+    case Preferences = "Preferences"
+    static func preferencesViewController() -> UITableViewController {
+      return Wizard.Preferences.viewController() as! UITableViewController
+    }
+
+    case Validate_Password = "Validate_Password"
+    static func validatePasswordViewController() -> UIViewController {
+      return Wizard.Validate_Password.viewController()
+    }
+  }
+}
+
+struct XCTStoryboardsSegue {
+  enum Message : String, StoryboardSegue {
+    case CustomBack = "CustomBack"
+    case Embed = "Embed"
+    case NonCustom = "NonCustom"
+    case Show_NavCtrl = "Show-NavCtrl"
+  }
+  enum Wizard : String, StoryboardSegue {
+    case ShowPassword = "ShowPassword"
   }
 }

--- a/UnitTests/expected/Storyboards-All-CustomName.swift.out
+++ b/UnitTests/expected/Storyboards-All-CustomName.swift.out
@@ -3,11 +3,11 @@
 import Foundation
 import UIKit
 
-protocol StoryboardScene {
+protocol StoryboardSceneType {
   static var storyboardName : String { get }
 }
 
-extension StoryboardScene {
+extension StoryboardSceneType {
   static func storyboard() -> UIStoryboard {
     return UIStoryboard(name: self.storyboardName, bundle: nil)
   }
@@ -17,7 +17,7 @@ extension StoryboardScene {
   }
 }
 
-extension StoryboardScene where Self: RawRepresentable, Self.RawValue == String {
+extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == String {
   func viewController() -> UIViewController {
     return Self.storyboard().instantiateViewControllerWithIdentifier(self.rawValue)
   }
@@ -26,19 +26,19 @@ extension StoryboardScene where Self: RawRepresentable, Self.RawValue == String 
   }
 }
 
-protocol StoryboardSegue : RawRepresentable { }
+protocol StoryboardSegueType : RawRepresentable { }
 
 extension UIViewController {
-  func performSegue<S : StoryboardSegue where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+  func performSegue<S : StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
     performSegueWithIdentifier(segue.rawValue, sender: sender)
   }
 }
 
 struct XCTStoryboardsScene {
-  enum Anonymous : StoryboardScene {
+  enum Anonymous : StoryboardSceneType {
     static let storyboardName = "Anonymous"
   }
-  enum Message : String, StoryboardScene {
+  enum Message : String, StoryboardSceneType {
     static let storyboardName = "Message"
 
     case Composer = "Composer"
@@ -61,7 +61,7 @@ struct XCTStoryboardsScene {
       return Message.URLChooser.viewController() as! XXPickerViewController
     }
   }
-  enum Wizard : String, StoryboardScene {
+  enum Wizard : String, StoryboardSceneType {
     static let storyboardName = "Wizard"
 
     case Accept_CGU = "Accept-CGU"
@@ -87,13 +87,13 @@ struct XCTStoryboardsScene {
 }
 
 struct XCTStoryboardsSegue {
-  enum Message : String, StoryboardSegue {
+  enum Message : String, StoryboardSegueType {
     case CustomBack = "CustomBack"
     case Embed = "Embed"
     case NonCustom = "NonCustom"
     case Show_NavCtrl = "Show-NavCtrl"
   }
-  enum Wizard : String, StoryboardSegue {
+  enum Wizard : String, StoryboardSegueType {
     case ShowPassword = "ShowPassword"
   }
 }

--- a/UnitTests/expected/Storyboards-All-Defaults.swift.out
+++ b/UnitTests/expected/Storyboards-All-Defaults.swift.out
@@ -3,11 +3,11 @@
 import Foundation
 import UIKit
 
-protocol StoryboardScene {
+protocol StoryboardSceneType {
   static var storyboardName : String { get }
 }
 
-extension StoryboardScene {
+extension StoryboardSceneType {
   static func storyboard() -> UIStoryboard {
     return UIStoryboard(name: self.storyboardName, bundle: nil)
   }
@@ -17,7 +17,7 @@ extension StoryboardScene {
   }
 }
 
-extension StoryboardScene where Self: RawRepresentable, Self.RawValue == String {
+extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == String {
   func viewController() -> UIViewController {
     return Self.storyboard().instantiateViewControllerWithIdentifier(self.rawValue)
   }
@@ -26,19 +26,19 @@ extension StoryboardScene where Self: RawRepresentable, Self.RawValue == String 
   }
 }
 
-protocol StoryboardSegue : RawRepresentable { }
+protocol StoryboardSegueType : RawRepresentable { }
 
 extension UIViewController {
-  func performSegue<S : StoryboardSegue where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+  func performSegue<S : StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
     performSegueWithIdentifier(segue.rawValue, sender: sender)
   }
 }
 
 struct Scene {
-  enum Anonymous : StoryboardScene {
+  enum Anonymous : StoryboardSceneType {
     static let storyboardName = "Anonymous"
   }
-  enum Message : String, StoryboardScene {
+  enum Message : String, StoryboardSceneType {
     static let storyboardName = "Message"
 
     case Composer = "Composer"
@@ -61,7 +61,7 @@ struct Scene {
       return Message.URLChooser.viewController() as! XXPickerViewController
     }
   }
-  enum Wizard : String, StoryboardScene {
+  enum Wizard : String, StoryboardSceneType {
     static let storyboardName = "Wizard"
 
     case Accept_CGU = "Accept-CGU"
@@ -87,13 +87,13 @@ struct Scene {
 }
 
 struct Segue {
-  enum Message : String, StoryboardSegue {
+  enum Message : String, StoryboardSegueType {
     case CustomBack = "CustomBack"
     case Embed = "Embed"
     case NonCustom = "NonCustom"
     case Show_NavCtrl = "Show-NavCtrl"
   }
-  enum Wizard : String, StoryboardSegue {
+  enum Wizard : String, StoryboardSegueType {
     case ShowPassword = "ShowPassword"
   }
 }

--- a/UnitTests/expected/Storyboards-All-Defaults.swift.out
+++ b/UnitTests/expected/Storyboards-All-Defaults.swift.out
@@ -34,68 +34,66 @@ extension UIViewController {
   }
 }
 
-extension UIStoryboard {
-  struct Scene {
-    enum Anonymous : StoryboardScene {
-      static let storyboardName = "Anonymous"
+struct Scene {
+  enum Anonymous : StoryboardScene {
+    static let storyboardName = "Anonymous"
+  }
+  enum Message : String, StoryboardScene {
+    static let storyboardName = "Message"
+
+    case Composer = "Composer"
+    static func composerViewController() -> UIViewController {
+      return Message.Composer.viewController()
     }
-    enum Message : String, StoryboardScene {
-      static let storyboardName = "Message"
 
-      case Composer = "Composer"
-      static func composerViewController() -> UIViewController {
-        return Message.Composer.viewController()
-      }
-
-      case MessagesList = "MessagesList"
-      static func messagesListViewController() -> UITableViewController {
-        return Message.MessagesList.viewController() as! UITableViewController
-      }
-
-      case NavCtrl = "NavCtrl"
-      static func navCtrlViewController() -> UINavigationController {
-        return Message.NavCtrl.viewController() as! UINavigationController
-      }
-
-      case URLChooser = "URLChooser"
-      static func urlChooserViewController() -> XXPickerViewController {
-        return Message.URLChooser.viewController() as! XXPickerViewController
-      }
+    case MessagesList = "MessagesList"
+    static func messagesListViewController() -> UITableViewController {
+      return Message.MessagesList.viewController() as! UITableViewController
     }
-    enum Wizard : String, StoryboardScene {
-      static let storyboardName = "Wizard"
 
-      case Accept_CGU = "Accept-CGU"
-      static func acceptCGUViewController() -> UIViewController {
-        return Wizard.Accept_CGU.viewController()
-      }
+    case NavCtrl = "NavCtrl"
+    static func navCtrlViewController() -> UINavigationController {
+      return Message.NavCtrl.viewController() as! UINavigationController
+    }
 
-      case CreateAccount = "CreateAccount"
-      static func createAccountViewController() -> CreateAccViewController {
-        return Wizard.CreateAccount.viewController() as! CreateAccViewController
-      }
-
-      case Preferences = "Preferences"
-      static func preferencesViewController() -> UITableViewController {
-        return Wizard.Preferences.viewController() as! UITableViewController
-      }
-
-      case Validate_Password = "Validate_Password"
-      static func validatePasswordViewController() -> UIViewController {
-        return Wizard.Validate_Password.viewController()
-      }
+    case URLChooser = "URLChooser"
+    static func urlChooserViewController() -> XXPickerViewController {
+      return Message.URLChooser.viewController() as! XXPickerViewController
     }
   }
+  enum Wizard : String, StoryboardScene {
+    static let storyboardName = "Wizard"
 
-  struct Segue {
-    enum Message : String, StoryboardSegue {
-      case CustomBack = "CustomBack"
-      case Embed = "Embed"
-      case NonCustom = "NonCustom"
-      case Show_NavCtrl = "Show-NavCtrl"
+    case Accept_CGU = "Accept-CGU"
+    static func acceptCGUViewController() -> UIViewController {
+      return Wizard.Accept_CGU.viewController()
     }
-    enum Wizard : String, StoryboardSegue {
-      case ShowPassword = "ShowPassword"
+
+    case CreateAccount = "CreateAccount"
+    static func createAccountViewController() -> CreateAccViewController {
+      return Wizard.CreateAccount.viewController() as! CreateAccViewController
     }
+
+    case Preferences = "Preferences"
+    static func preferencesViewController() -> UITableViewController {
+      return Wizard.Preferences.viewController() as! UITableViewController
+    }
+
+    case Validate_Password = "Validate_Password"
+    static func validatePasswordViewController() -> UIViewController {
+      return Wizard.Validate_Password.viewController()
+    }
+  }
+}
+
+struct Segue {
+  enum Message : String, StoryboardSegue {
+    case CustomBack = "CustomBack"
+    case Embed = "Embed"
+    case NonCustom = "NonCustom"
+    case Show_NavCtrl = "Show-NavCtrl"
+  }
+  enum Wizard : String, StoryboardSegue {
+    case ShowPassword = "ShowPassword"
   }
 }

--- a/UnitTests/expected/Storyboards-All-Defaults.swift.out
+++ b/UnitTests/expected/Storyboards-All-Defaults.swift.out
@@ -34,7 +34,7 @@ extension UIViewController {
   }
 }
 
-struct Scene {
+struct StoryboardScene {
   enum Anonymous : StoryboardSceneType {
     static let storyboardName = "Anonymous"
   }
@@ -86,7 +86,7 @@ struct Scene {
   }
 }
 
-struct Segue {
+struct StoryboardSegue {
   enum Message : String, StoryboardSegueType {
     case CustomBack = "CustomBack"
     case Embed = "Embed"

--- a/UnitTests/expected/Storyboards-Anonymous-Defaults.swift.out
+++ b/UnitTests/expected/Storyboards-Anonymous-Defaults.swift.out
@@ -34,13 +34,11 @@ extension UIViewController {
   }
 }
 
-extension UIStoryboard {
-  struct Scene {
-    enum Anonymous : StoryboardScene {
-      static let storyboardName = "Anonymous"
-    }
+struct Scene {
+  enum Anonymous : StoryboardScene {
+    static let storyboardName = "Anonymous"
   }
+}
 
-  struct Segue {
-  }
+struct Segue {
 }

--- a/UnitTests/expected/Storyboards-Anonymous-Defaults.swift.out
+++ b/UnitTests/expected/Storyboards-Anonymous-Defaults.swift.out
@@ -34,11 +34,11 @@ extension UIViewController {
   }
 }
 
-struct Scene {
+struct StoryboardScene {
   enum Anonymous : StoryboardSceneType {
     static let storyboardName = "Anonymous"
   }
 }
 
-struct Segue {
+struct StoryboardSegue {
 }

--- a/UnitTests/expected/Storyboards-Anonymous-Defaults.swift.out
+++ b/UnitTests/expected/Storyboards-Anonymous-Defaults.swift.out
@@ -3,11 +3,11 @@
 import Foundation
 import UIKit
 
-protocol StoryboardScene {
+protocol StoryboardSceneType {
   static var storyboardName : String { get }
 }
 
-extension StoryboardScene {
+extension StoryboardSceneType {
   static func storyboard() -> UIStoryboard {
     return UIStoryboard(name: self.storyboardName, bundle: nil)
   }
@@ -17,7 +17,7 @@ extension StoryboardScene {
   }
 }
 
-extension StoryboardScene where Self: RawRepresentable, Self.RawValue == String {
+extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == String {
   func viewController() -> UIViewController {
     return Self.storyboard().instantiateViewControllerWithIdentifier(self.rawValue)
   }
@@ -26,16 +26,16 @@ extension StoryboardScene where Self: RawRepresentable, Self.RawValue == String 
   }
 }
 
-protocol StoryboardSegue : RawRepresentable { }
+protocol StoryboardSegueType : RawRepresentable { }
 
 extension UIViewController {
-  func performSegue<S : StoryboardSegue where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+  func performSegue<S : StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
     performSegueWithIdentifier(segue.rawValue, sender: sender)
   }
 }
 
 struct Scene {
-  enum Anonymous : StoryboardScene {
+  enum Anonymous : StoryboardSceneType {
     static let storyboardName = "Anonymous"
   }
 }

--- a/UnitTests/expected/Storyboards-Empty.swift.out
+++ b/UnitTests/expected/Storyboards-Empty.swift.out
@@ -3,11 +3,11 @@
 import Foundation
 import UIKit
 
-protocol StoryboardScene {
+protocol StoryboardSceneType {
   static var storyboardName : String { get }
 }
 
-extension StoryboardScene {
+extension StoryboardSceneType {
   static func storyboard() -> UIStoryboard {
     return UIStoryboard(name: self.storyboardName, bundle: nil)
   }
@@ -17,7 +17,7 @@ extension StoryboardScene {
   }
 }
 
-extension StoryboardScene where Self: RawRepresentable, Self.RawValue == String {
+extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == String {
   func viewController() -> UIViewController {
     return Self.storyboard().instantiateViewControllerWithIdentifier(self.rawValue)
   }
@@ -26,10 +26,10 @@ extension StoryboardScene where Self: RawRepresentable, Self.RawValue == String 
   }
 }
 
-protocol StoryboardSegue : RawRepresentable { }
+protocol StoryboardSegueType : RawRepresentable { }
 
 extension UIViewController {
-  func performSegue<S : StoryboardSegue where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+  func performSegue<S : StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
     performSegueWithIdentifier(segue.rawValue, sender: sender)
   }
 }

--- a/UnitTests/expected/Storyboards-Message-Defaults.swift.out
+++ b/UnitTests/expected/Storyboards-Message-Defaults.swift.out
@@ -34,7 +34,7 @@ extension UIViewController {
   }
 }
 
-struct Scene {
+struct StoryboardScene {
   enum Message : String, StoryboardSceneType {
     static let storyboardName = "Message"
 
@@ -60,7 +60,7 @@ struct Scene {
   }
 }
 
-struct Segue {
+struct StoryboardSegue {
   enum Message : String, StoryboardSegueType {
     case CustomBack = "CustomBack"
     case Embed = "Embed"

--- a/UnitTests/expected/Storyboards-Message-Defaults.swift.out
+++ b/UnitTests/expected/Storyboards-Message-Defaults.swift.out
@@ -3,11 +3,11 @@
 import Foundation
 import UIKit
 
-protocol StoryboardScene {
+protocol StoryboardSceneType {
   static var storyboardName : String { get }
 }
 
-extension StoryboardScene {
+extension StoryboardSceneType {
   static func storyboard() -> UIStoryboard {
     return UIStoryboard(name: self.storyboardName, bundle: nil)
   }
@@ -17,7 +17,7 @@ extension StoryboardScene {
   }
 }
 
-extension StoryboardScene where Self: RawRepresentable, Self.RawValue == String {
+extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == String {
   func viewController() -> UIViewController {
     return Self.storyboard().instantiateViewControllerWithIdentifier(self.rawValue)
   }
@@ -26,16 +26,16 @@ extension StoryboardScene where Self: RawRepresentable, Self.RawValue == String 
   }
 }
 
-protocol StoryboardSegue : RawRepresentable { }
+protocol StoryboardSegueType : RawRepresentable { }
 
 extension UIViewController {
-  func performSegue<S : StoryboardSegue where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+  func performSegue<S : StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
     performSegueWithIdentifier(segue.rawValue, sender: sender)
   }
 }
 
 struct Scene {
-  enum Message : String, StoryboardScene {
+  enum Message : String, StoryboardSceneType {
     static let storyboardName = "Message"
 
     case Composer = "Composer"
@@ -61,7 +61,7 @@ struct Scene {
 }
 
 struct Segue {
-  enum Message : String, StoryboardSegue {
+  enum Message : String, StoryboardSegueType {
     case CustomBack = "CustomBack"
     case Embed = "Embed"
     case NonCustom = "NonCustom"

--- a/UnitTests/expected/Storyboards-Message-Defaults.swift.out
+++ b/UnitTests/expected/Storyboards-Message-Defaults.swift.out
@@ -34,39 +34,37 @@ extension UIViewController {
   }
 }
 
-extension UIStoryboard {
-  struct Scene {
-    enum Message : String, StoryboardScene {
-      static let storyboardName = "Message"
+struct Scene {
+  enum Message : String, StoryboardScene {
+    static let storyboardName = "Message"
 
-      case Composer = "Composer"
-      static func composerViewController() -> UIViewController {
-        return Message.Composer.viewController()
-      }
+    case Composer = "Composer"
+    static func composerViewController() -> UIViewController {
+      return Message.Composer.viewController()
+    }
 
-      case MessagesList = "MessagesList"
-      static func messagesListViewController() -> UITableViewController {
-        return Message.MessagesList.viewController() as! UITableViewController
-      }
+    case MessagesList = "MessagesList"
+    static func messagesListViewController() -> UITableViewController {
+      return Message.MessagesList.viewController() as! UITableViewController
+    }
 
-      case NavCtrl = "NavCtrl"
-      static func navCtrlViewController() -> UINavigationController {
-        return Message.NavCtrl.viewController() as! UINavigationController
-      }
+    case NavCtrl = "NavCtrl"
+    static func navCtrlViewController() -> UINavigationController {
+      return Message.NavCtrl.viewController() as! UINavigationController
+    }
 
-      case URLChooser = "URLChooser"
-      static func urlChooserViewController() -> XXPickerViewController {
-        return Message.URLChooser.viewController() as! XXPickerViewController
-      }
+    case URLChooser = "URLChooser"
+    static func urlChooserViewController() -> XXPickerViewController {
+      return Message.URLChooser.viewController() as! XXPickerViewController
     }
   }
+}
 
-  struct Segue {
-    enum Message : String, StoryboardSegue {
-      case CustomBack = "CustomBack"
-      case Embed = "Embed"
-      case NonCustom = "NonCustom"
-      case Show_NavCtrl = "Show-NavCtrl"
-    }
+struct Segue {
+  enum Message : String, StoryboardSegue {
+    case CustomBack = "CustomBack"
+    case Embed = "Embed"
+    case NonCustom = "NonCustom"
+    case Show_NavCtrl = "Show-NavCtrl"
   }
 }

--- a/UnitTests/expected/Storyboards-Message-Lowercase.swift.out
+++ b/UnitTests/expected/Storyboards-Message-Lowercase.swift.out
@@ -34,7 +34,7 @@ extension UIViewController {
   }
 }
 
-struct Scene {
+struct StoryboardScene {
   enum Message : String, StoryboardSceneType {
     static let storyboardName = "Message"
 
@@ -60,7 +60,7 @@ struct Scene {
   }
 }
 
-struct Segue {
+struct StoryboardSegue {
   enum Message : String, StoryboardSegueType {
     case CustomBack = "CustomBack"
     case Embed = "Embed"

--- a/UnitTests/expected/Storyboards-Message-Lowercase.swift.out
+++ b/UnitTests/expected/Storyboards-Message-Lowercase.swift.out
@@ -34,39 +34,37 @@ extension UIViewController {
   }
 }
 
-extension UIStoryboard {
-  struct Scene {
-    enum Message : String, StoryboardScene {
-      static let storyboardName = "Message"
+struct Scene {
+  enum Message : String, StoryboardScene {
+    static let storyboardName = "Message"
 
-      case composer = "Composer"
-      static func composerViewController() -> UIViewController {
-        return Message.composer.viewController()
-      }
+    case composer = "Composer"
+    static func composerViewController() -> UIViewController {
+      return Message.composer.viewController()
+    }
 
-      case messagesList = "MessagesList"
-      static func messagesListViewController() -> UITableViewController {
-        return Message.messagesList.viewController() as! UITableViewController
-      }
+    case messagesList = "MessagesList"
+    static func messagesListViewController() -> UITableViewController {
+      return Message.messagesList.viewController() as! UITableViewController
+    }
 
-      case navCtrl = "NavCtrl"
-      static func navCtrlViewController() -> UINavigationController {
-        return Message.navCtrl.viewController() as! UINavigationController
-      }
+    case navCtrl = "NavCtrl"
+    static func navCtrlViewController() -> UINavigationController {
+      return Message.navCtrl.viewController() as! UINavigationController
+    }
 
-      case urlChooser = "URLChooser"
-      static func urlChooserViewController() -> XXPickerViewController {
-        return Message.urlChooser.viewController() as! XXPickerViewController
-      }
+    case urlChooser = "URLChooser"
+    static func urlChooserViewController() -> XXPickerViewController {
+      return Message.urlChooser.viewController() as! XXPickerViewController
     }
   }
+}
 
-  struct Segue {
-    enum Message : String, StoryboardSegue {
-      case CustomBack = "CustomBack"
-      case Embed = "Embed"
-      case NonCustom = "NonCustom"
-      case Show_NavCtrl = "Show-NavCtrl"
-    }
+struct Segue {
+  enum Message : String, StoryboardSegue {
+    case CustomBack = "CustomBack"
+    case Embed = "Embed"
+    case NonCustom = "NonCustom"
+    case Show_NavCtrl = "Show-NavCtrl"
   }
 }

--- a/UnitTests/expected/Storyboards-Message-Lowercase.swift.out
+++ b/UnitTests/expected/Storyboards-Message-Lowercase.swift.out
@@ -3,11 +3,11 @@
 import Foundation
 import UIKit
 
-protocol StoryboardScene {
+protocol StoryboardSceneType {
   static var storyboardName : String { get }
 }
 
-extension StoryboardScene {
+extension StoryboardSceneType {
   static func storyboard() -> UIStoryboard {
     return UIStoryboard(name: self.storyboardName, bundle: nil)
   }
@@ -17,7 +17,7 @@ extension StoryboardScene {
   }
 }
 
-extension StoryboardScene where Self: RawRepresentable, Self.RawValue == String {
+extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == String {
   func viewController() -> UIViewController {
     return Self.storyboard().instantiateViewControllerWithIdentifier(self.rawValue)
   }
@@ -26,16 +26,16 @@ extension StoryboardScene where Self: RawRepresentable, Self.RawValue == String 
   }
 }
 
-protocol StoryboardSegue : RawRepresentable { }
+protocol StoryboardSegueType : RawRepresentable { }
 
 extension UIViewController {
-  func performSegue<S : StoryboardSegue where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+  func performSegue<S : StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
     performSegueWithIdentifier(segue.rawValue, sender: sender)
   }
 }
 
 struct Scene {
-  enum Message : String, StoryboardScene {
+  enum Message : String, StoryboardSceneType {
     static let storyboardName = "Message"
 
     case composer = "Composer"
@@ -61,7 +61,7 @@ struct Scene {
 }
 
 struct Segue {
-  enum Message : String, StoryboardSegue {
+  enum Message : String, StoryboardSegueType {
     case CustomBack = "CustomBack"
     case Embed = "Embed"
     case NonCustom = "NonCustom"

--- a/swiftgen-cli/storyboards.swift
+++ b/swiftgen-cli/storyboards.swift
@@ -11,8 +11,8 @@ import GenumKit
 let storyboardsCommand = command(
   outputOption,
   templateOption("storyboards"), templatePathOption,
-  Option<String>("sceneEnumName", "Scene", flag: "e", description: "The name of the enum to generate for Scenes"),
-  Option<String>("segueEnumName", "Segue", flag: "g", description: "The name of the enum to generate for Segues"),
+  Option<String>("sceneEnumName", "StoryboardScene", flag: "e", description: "The name of the enum to generate for Scenes"),
+  Option<String>("segueEnumName", "StoryboardSegue", flag: "g", description: "The name of the enum to generate for Segues"),
   Argument<Path>("PATH", description: "Directory to scan for .storyboard files. Can also be a path to a single .storyboard", validator: pathExists)
 ) { output, templateName, templatePath, sceneEnumName, segueEnumName, path in
   let parser = StoryboardParser()

--- a/templates/storyboards-default.stencil
+++ b/templates/storyboards-default.stencil
@@ -4,11 +4,11 @@ import Foundation
 import UIKit
 
 {# This first part of the code is static, same every time whatever Storyboard you have #}
-protocol StoryboardScene {
+protocol StoryboardSceneType {
   static var storyboardName : String { get }
 }
 
-extension StoryboardScene {
+extension StoryboardSceneType {
   static func storyboard() -> UIStoryboard {
     return UIStoryboard(name: self.storyboardName, bundle: nil)
   }
@@ -18,7 +18,7 @@ extension StoryboardScene {
   }
 }
 
-extension StoryboardScene where Self: RawRepresentable, Self.RawValue == String {
+extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == String {
   func viewController() -> UIViewController {
     return Self.storyboard().instantiateViewControllerWithIdentifier(self.rawValue)
   }
@@ -27,10 +27,10 @@ extension StoryboardScene where Self: RawRepresentable, Self.RawValue == String 
   }
 }
 
-protocol StoryboardSegue : RawRepresentable { }
+protocol StoryboardSegueType : RawRepresentable { }
 
 extension UIViewController {
-  func performSegue<S : StoryboardSegue where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+  func performSegue<S : StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
     performSegueWithIdentifier(segue.rawValue, sender: sender)
   }
 }
@@ -41,7 +41,7 @@ struct {{sceneEnumName}} {
   {% for storyboard in storyboards %}
   {% set storyboardName %}{{storyboard.name|swiftIdentifier}}{% endset %}
   {% if storyboard.scenes %}
-  enum {{storyboardName}} : String, StoryboardScene {
+  enum {{storyboardName}} : String, StoryboardSceneType {
     static let storyboardName = "{{storyboard.name}}"
     {% for scene in storyboard.scenes %}
     {% set sceneID %}{{scene.identifier|swiftIdentifier}}{% endset %}
@@ -59,7 +59,7 @@ struct {{sceneEnumName}} {
     {% endfor %}
   }
   {% else %}
-  enum {{storyboardName}} : StoryboardScene {
+  enum {{storyboardName}} : StoryboardSceneType {
     static let storyboardName = "{{storyboard.name}}"
   }
   {% endif %}
@@ -68,7 +68,7 @@ struct {{sceneEnumName}} {
 
 struct {{segueEnumName}} {
   {% for storyboard in storyboards %}{% if storyboard.segues %}
-  enum {{storyboard.name|swiftIdentifier}} : String, StoryboardSegue {
+  enum {{storyboard.name|swiftIdentifier}} : String, StoryboardSegueType {
     {% for segue in storyboard.segues %}
     case {{segue.identifier|swiftIdentifier}} = "{{segue.identifier}}"
     {% endfor %}

--- a/templates/storyboards-default.stencil
+++ b/templates/storyboards-default.stencil
@@ -37,45 +37,43 @@ extension UIViewController {
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
 {% if storyboards %}
-extension UIStoryboard {
-  struct {{sceneEnumName}} {
-    {% for storyboard in storyboards %}
-    {% set storyboardName %}{{storyboard.name|swiftIdentifier}}{% endset %}
-    {% if storyboard.scenes %}
-    enum {{storyboardName}} : String, StoryboardScene {
-      static let storyboardName = "{{storyboard.name}}"
-      {% for scene in storyboard.scenes %}
-      {% set sceneID %}{{scene.identifier|swiftIdentifier}}{% endset %}
+struct {{sceneEnumName}} {
+  {% for storyboard in storyboards %}
+  {% set storyboardName %}{{storyboard.name|swiftIdentifier}}{% endset %}
+  {% if storyboard.scenes %}
+  enum {{storyboardName}} : String, StoryboardScene {
+    static let storyboardName = "{{storyboard.name}}"
+    {% for scene in storyboard.scenes %}
+    {% set sceneID %}{{scene.identifier|swiftIdentifier}}{% endset %}
 
-      case {{sceneID}} = "{{scene.identifier}}"
-      {% if scene.class %}
-      static func {{sceneID|snakeToCamelCase|lowerFirstWord}}ViewController() -> {{scene.class}} {
-        return {{storyboardName}}.{{sceneID}}.viewController() as! {{scene.class}}
-      }
-      {% else %}
-      static func {{sceneID|snakeToCamelCase|lowerFirstWord}}ViewController() -> UIViewController {
-        return {{storyboardName}}.{{sceneID}}.viewController()
-      }
-      {% endif %}
-      {% endfor %}
+    case {{sceneID}} = "{{scene.identifier}}"
+    {% if scene.class %}
+    static func {{sceneID|snakeToCamelCase|lowerFirstWord}}ViewController() -> {{scene.class}} {
+      return {{storyboardName}}.{{sceneID}}.viewController() as! {{scene.class}}
     }
     {% else %}
-    enum {{storyboardName}} : StoryboardScene {
-      static let storyboardName = "{{storyboard.name}}"
+    static func {{sceneID|snakeToCamelCase|lowerFirstWord}}ViewController() -> UIViewController {
+      return {{storyboardName}}.{{sceneID}}.viewController()
     }
     {% endif %}
     {% endfor %}
   }
-
-  struct {{segueEnumName}} {
-    {% for storyboard in storyboards %}{% if storyboard.segues %}
-    enum {{storyboard.name|swiftIdentifier}} : String, StoryboardSegue {
-      {% for segue in storyboard.segues %}
-      case {{segue.identifier|swiftIdentifier}} = "{{segue.identifier}}"
-      {% endfor %}
-    }
-    {% endif %}{% endfor %}
+  {% else %}
+  enum {{storyboardName}} : StoryboardScene {
+    static let storyboardName = "{{storyboard.name}}"
   }
+  {% endif %}
+  {% endfor %}
+}
+
+struct {{segueEnumName}} {
+  {% for storyboard in storyboards %}{% if storyboard.segues %}
+  enum {{storyboard.name|swiftIdentifier}} : String, StoryboardSegue {
+    {% for segue in storyboard.segues %}
+    case {{segue.identifier|swiftIdentifier}} = "{{segue.identifier}}"
+    {% endfor %}
+  }
+  {% endif %}{% endfor %}
 }
 {% else %}
 // No storyboard found

--- a/templates/storyboards-lowercase.stencil
+++ b/templates/storyboards-lowercase.stencil
@@ -4,11 +4,11 @@ import Foundation
 import UIKit
 
 {# This first part of the code is static, same every time whatever Storyboard you have #}
-protocol StoryboardScene {
+protocol StoryboardSceneType {
   static var storyboardName : String { get }
 }
 
-extension StoryboardScene {
+extension StoryboardSceneType {
   static func storyboard() -> UIStoryboard {
     return UIStoryboard(name: self.storyboardName, bundle: nil)
   }
@@ -18,7 +18,7 @@ extension StoryboardScene {
   }
 }
 
-extension StoryboardScene where Self: RawRepresentable, Self.RawValue == String {
+extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == String {
   func viewController() -> UIViewController {
     return Self.storyboard().instantiateViewControllerWithIdentifier(self.rawValue)
   }
@@ -27,10 +27,10 @@ extension StoryboardScene where Self: RawRepresentable, Self.RawValue == String 
   }
 }
 
-protocol StoryboardSegue : RawRepresentable { }
+protocol StoryboardSegueType : RawRepresentable { }
 
 extension UIViewController {
-  func performSegue<S : StoryboardSegue where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+  func performSegue<S : StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
     performSegueWithIdentifier(segue.rawValue, sender: sender)
   }
 }
@@ -41,7 +41,7 @@ struct {{sceneEnumName}} {
   {% for storyboard in storyboards %}
   {% set storyboardName %}{{storyboard.name|swiftIdentifier}}{% endset %}
   {% if storyboard.scenes %}
-  enum {{storyboardName}} : String, StoryboardScene {
+  enum {{storyboardName}} : String, StoryboardSceneType {
     static let storyboardName = "{{storyboard.name}}"
     {% for scene in storyboard.scenes %}
     {% set sceneID %}{{scene.identifier|swiftIdentifier|lowerFirstWord}}{% endset %}
@@ -59,7 +59,7 @@ struct {{sceneEnumName}} {
     {% endfor %}
   }
   {% else %}
-  enum {{storyboardName}} : StoryboardScene {
+  enum {{storyboardName}} : StoryboardSceneType {
     static let storyboardName = "{{storyboard.name}}"
   }
   {% endif %}
@@ -68,7 +68,7 @@ struct {{sceneEnumName}} {
 
 struct {{segueEnumName}} {
   {% for storyboard in storyboards %}{% if storyboard.segues %}
-  enum {{storyboard.name|swiftIdentifier}} : String, StoryboardSegue {
+  enum {{storyboard.name|swiftIdentifier}} : String, StoryboardSegueType {
     {% for segue in storyboard.segues %}
     case {{segue.identifier|swiftIdentifier}} = "{{segue.identifier}}"
     {% endfor %}

--- a/templates/storyboards-lowercase.stencil
+++ b/templates/storyboards-lowercase.stencil
@@ -37,45 +37,43 @@ extension UIViewController {
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
 {% if storyboards %}
-extension UIStoryboard {
-  struct {{sceneEnumName}} {
-    {% for storyboard in storyboards %}
-    {% set storyboardName %}{{storyboard.name|swiftIdentifier}}{% endset %}
-    {% if storyboard.scenes %}
-    enum {{storyboardName}} : String, StoryboardScene {
-      static let storyboardName = "{{storyboard.name}}"
-      {% for scene in storyboard.scenes %}
-      {% set sceneID %}{{scene.identifier|swiftIdentifier|lowerFirstWord}}{% endset %}
+struct {{sceneEnumName}} {
+  {% for storyboard in storyboards %}
+  {% set storyboardName %}{{storyboard.name|swiftIdentifier}}{% endset %}
+  {% if storyboard.scenes %}
+  enum {{storyboardName}} : String, StoryboardScene {
+    static let storyboardName = "{{storyboard.name}}"
+    {% for scene in storyboard.scenes %}
+    {% set sceneID %}{{scene.identifier|swiftIdentifier|lowerFirstWord}}{% endset %}
 
-      case {{sceneID}} = "{{scene.identifier}}"
-      {% if scene.class %}
-      static func {{sceneID}}ViewController() -> {{scene.class}} {
-        return {{storyboardName}}.{{sceneID}}.viewController() as! {{scene.class}}
-      }
-      {% else %}
-      static func {{sceneID|lowerFirstWord}}ViewController() -> UIViewController {
-        return {{storyboardName}}.{{sceneID}}.viewController()
-      }
-      {% endif %}
-      {% endfor %}
+    case {{sceneID}} = "{{scene.identifier}}"
+    {% if scene.class %}
+    static func {{sceneID}}ViewController() -> {{scene.class}} {
+      return {{storyboardName}}.{{sceneID}}.viewController() as! {{scene.class}}
     }
     {% else %}
-    enum {{storyboardName}} : StoryboardScene {
-      static let storyboardName = "{{storyboard.name}}"
+    static func {{sceneID|lowerFirstWord}}ViewController() -> UIViewController {
+      return {{storyboardName}}.{{sceneID}}.viewController()
     }
     {% endif %}
     {% endfor %}
   }
-
-  struct {{segueEnumName}} {
-    {% for storyboard in storyboards %}{% if storyboard.segues %}
-    enum {{storyboard.name|swiftIdentifier}} : String, StoryboardSegue {
-      {% for segue in storyboard.segues %}
-      case {{segue.identifier|swiftIdentifier}} = "{{segue.identifier}}"
-      {% endfor %}
-    }
-    {% endif %}{% endfor %}
+  {% else %}
+  enum {{storyboardName}} : StoryboardScene {
+    static let storyboardName = "{{storyboard.name}}"
   }
+  {% endif %}
+  {% endfor %}
+}
+
+struct {{segueEnumName}} {
+  {% for storyboard in storyboards %}{% if storyboard.segues %}
+  enum {{storyboard.name|swiftIdentifier}} : String, StoryboardSegue {
+    {% for segue in storyboard.segues %}
+    case {{segue.identifier|swiftIdentifier}} = "{{segue.identifier}}"
+    {% endfor %}
+  }
+  {% endif %}{% endfor %}
 }
 {% else %}
 // No storyboard found


### PR DESCRIPTION
Works around https://github.com/AliSoftware/SwiftGen/issues/57

I've left the default Segue and Scene names as is. We can't use StoryboardScene and StoryboardSegue as they conflict with the protocols. I'm not attached to a particular name if anyone has something better.