### PR TITLE
Updated ReadME to use StoryboardScene and StoryboardSegue

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,14 +290,14 @@ struct StoryboardSegue {
 
 ```swift
 // Initial VC
-let initialVC = UIStoryboard.Scene.Wizard.initialViewController()
+let initialVC = StoryboardScene.Wizard.initialViewController()
 // Generic ViewController constructor, returns a UIViewController instance
-let validateVC = UIStoryboard.Scene.Wizard.ValidatePassword.viewController()
+let validateVC = StoryboardScene.Wizard.ValidatePassword.viewController()
 // Dedicated type var that returns the right type of VC (CreateAccViewController here)
-let createVC = UIStoryboard.Scene.Wizard.createAccountViewController()
+let createVC = StoryboardScene.Wizard.createAccountViewController()
 
 override func prepareForSegue(_ segue: UIStoryboardSegue, sender sender: AnyObject?) {
-  switch UIStoryboard.Segue.Message(rawValue: segue.identifier)! {
+  switch StoryboardSegue.Message(rawValue: segue.identifier)! {
   case .Back:
     // Prepare for your custom segue transition
   case .Custom:
@@ -307,7 +307,7 @@ override func prepareForSegue(_ segue: UIStoryboardSegue, sender sender: AnyObje
   }
 }
 
-initialVC.performSegue(UIStoryboard.Segue.Message.Back)
+initialVC.performSegue(StoryboardSegue.Message.Back)
 ```
 
 


### PR DESCRIPTION
When following the README Xcode complained of the following problem:

Code:

`UIStoryboard.Scene.Login.Start` 

Error:

`Type 'UIStoryboard' has no member 'Scene'`

This is due to UIStoryboard not being extended, a solution is provided where `UIStoryboard.Scene` is replaced with `StoryboardScene`.

The same is true for `UIStoryboard.Segue` to `StoryboardSegue`