### PR TITLE
Update colons to pass SwiftLint

### DIFF
--- a/templates/images-default.stencil
+++ b/templates/images-default.stencil
@@ -5,7 +5,7 @@ import Foundation
 import UIKit
 
 extension UIImage {
-  enum {{enumName}} : String {
+  enum {{enumName}}: String {
     {% for image in images %}
     case {{image|swiftIdentifier}} = "{{image}}"
     {% endfor %}

--- a/templates/storyboards-default.stencil
+++ b/templates/storyboards-default.stencil
@@ -27,10 +27,10 @@ extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == Str
   }
 }
 
-protocol StoryboardSegueType : RawRepresentable { }
+protocol StoryboardSegueType: RawRepresentable { }
 
 extension UIViewController {
-  func performSegue<S : StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
     performSegueWithIdentifier(segue.rawValue, sender: sender)
   }
 }
@@ -41,7 +41,7 @@ struct {{sceneEnumName}} {
   {% for storyboard in storyboards %}
   {% set storyboardName %}{{storyboard.name|swiftIdentifier}}{% endset %}
   {% if storyboard.scenes %}
-  enum {{storyboardName}} : String, StoryboardSceneType {
+  enum {{storyboardName}}: String, StoryboardSceneType {
     static let storyboardName = "{{storyboard.name}}"
     {% for scene in storyboard.scenes %}
     {% set sceneID %}{{scene.identifier|swiftIdentifier}}{% endset %}
@@ -68,7 +68,7 @@ struct {{sceneEnumName}} {
 
 struct {{segueEnumName}} {
   {% for storyboard in storyboards %}{% if storyboard.segues %}
-  enum {{storyboard.name|swiftIdentifier}} : String, StoryboardSegueType {
+  enum {{storyboard.name|swiftIdentifier}}: String, StoryboardSegueType {
     {% for segue in storyboard.segues %}
     case {{segue.identifier|swiftIdentifier}} = "{{segue.identifier}}"
     {% endfor %}

--- a/templates/strings-default.stencil
+++ b/templates/strings-default.stencil
@@ -11,9 +11,9 @@ enum {{enumName}} {
 }
 
 extension {{enumName}} : CustomStringConvertible {
-  var description : String { return self.string }
+  var description: String { return self.string }
 
-  var string : String {
+  var string: String {
     switch self {
       {% for string in strings %}
       {% if string.params %}


### PR DESCRIPTION
To use SwiftGen in tandem with [SwiftLint](https://github.com/realm/SwiftLint) the colons on `strings-default.stencil`, `storyboards-default.stencil` and `images-default.stencil` need to be updated to remove the prefixing space.

I realise this is a trivial improvement, but will reduce compiler warnings when used with SwiftLint!

![storyboard stencil](http://i.imgur.com/Sgpa9xy.png "storyboard stencil")
![image stencil](http://i.imgur.com/BcAsRmi.png "image stencil")