### PR TITLE
Update colons to pass SwiftLint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # SwiftGen CHANGELOG
 
 ---
+## 0.7.5
+
+### Enhancements
+
+*  Updated stencils and unit tests to pass [SwiftLint](https://github.com/realm/SwiftLint).  
+  [Adam Gask](https://github.com/AJ9), [#79](https://github.com/AliSoftware/SwiftGen/pull/79)
+
 ## 0.7.4
 
 #### Enhancements

--- a/UnitTests/expected/Colors-List-RawValue.swift.out
+++ b/UnitTests/expected/Colors-List-RawValue.swift.out
@@ -14,7 +14,7 @@ extension UIColor {
 }
 
 extension UIColor {
-  enum Name : UInt32 {
+  enum Name: UInt32 {
     /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#ffcc00"></span>
     /// Alpha: 60% <br/> (0xffcc0099)
     case ArticleBackground = 0xffcc0099

--- a/UnitTests/expected/Images-Entries-Defaults.swift.out
+++ b/UnitTests/expected/Images-Entries-Defaults.swift.out
@@ -4,7 +4,7 @@ import Foundation
 import UIKit
 
 extension UIImage {
-  enum Asset : String {
+  enum Asset: String {
     case Green_Apple = "Green-Apple"
     case Red_Apple = "Red apple"
     case _2_Pears = "2-pears"

--- a/UnitTests/expected/Images-File-AllValues.swift.out
+++ b/UnitTests/expected/Images-File-AllValues.swift.out
@@ -4,7 +4,7 @@ import Foundation
 import UIKit
 
 extension UIImage {
-  enum Asset : String {
+  enum Asset: String {
     case Apple = "Apple"
     case Banana = "Banana"
 

--- a/UnitTests/expected/Images-File-CustomName.swift.out
+++ b/UnitTests/expected/Images-File-CustomName.swift.out
@@ -4,7 +4,7 @@ import Foundation
 import UIKit
 
 extension UIImage {
-  enum XCTImages : String {
+  enum XCTImages: String {
     case Apple = "Apple"
     case Banana = "Banana"
 

--- a/UnitTests/expected/Images-File-Defaults.swift.out
+++ b/UnitTests/expected/Images-File-Defaults.swift.out
@@ -4,7 +4,7 @@ import Foundation
 import UIKit
 
 extension UIImage {
-  enum Asset : String {
+  enum Asset: String {
     case Apple = "Apple"
     case Banana = "Banana"
 

--- a/UnitTests/expected/Storyboards-All-CustomName.swift.out
+++ b/UnitTests/expected/Storyboards-All-CustomName.swift.out
@@ -4,7 +4,7 @@ import Foundation
 import UIKit
 
 protocol StoryboardSceneType {
-  static var storyboardName : String { get }
+  static var storyboardName: String { get }
 }
 
 extension StoryboardSceneType {
@@ -26,19 +26,19 @@ extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == Str
   }
 }
 
-protocol StoryboardSegueType : RawRepresentable { }
+protocol StoryboardSegueType: RawRepresentable { }
 
 extension UIViewController {
-  func performSegue<S : StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
     performSegueWithIdentifier(segue.rawValue, sender: sender)
   }
 }
 
 struct XCTStoryboardsScene {
-  enum Anonymous : StoryboardSceneType {
+  enum Anonymous: StoryboardSceneType {
     static let storyboardName = "Anonymous"
   }
-  enum Dependency : String, StoryboardSceneType {
+  enum Dependency: String, StoryboardSceneType {
     static let storyboardName = "Dependency"
 
     case Dependent = "Dependent"
@@ -46,7 +46,7 @@ struct XCTStoryboardsScene {
       return XCTStoryboardsScene.Dependency.Dependent.viewController()
     }
   }
-  enum Message : String, StoryboardSceneType {
+  enum Message: String, StoryboardSceneType {
     static let storyboardName = "Message"
 
     case Composer = "Composer"
@@ -69,7 +69,7 @@ struct XCTStoryboardsScene {
       return XCTStoryboardsScene.Message.URLChooser.viewController() as! XXPickerViewController
     }
   }
-  enum Placeholder : String, StoryboardSceneType {
+  enum Placeholder: String, StoryboardSceneType {
     static let storyboardName = "Placeholder"
 
     case Navigation = "Navigation"
@@ -77,7 +77,7 @@ struct XCTStoryboardsScene {
       return XCTStoryboardsScene.Placeholder.Navigation.viewController() as! UINavigationController
     }
   }
-  enum Wizard : String, StoryboardSceneType {
+  enum Wizard: String, StoryboardSceneType {
     static let storyboardName = "Wizard"
 
     case Accept_CGU = "Accept-CGU"
@@ -103,13 +103,13 @@ struct XCTStoryboardsScene {
 }
 
 struct XCTStoryboardsSegue {
-  enum Message : String, StoryboardSegueType {
+  enum Message: String, StoryboardSegueType {
     case CustomBack = "CustomBack"
     case Embed = "Embed"
     case NonCustom = "NonCustom"
     case Show_NavCtrl = "Show-NavCtrl"
   }
-  enum Wizard : String, StoryboardSegueType {
+  enum Wizard: String, StoryboardSegueType {
     case ShowPassword = "ShowPassword"
   }
 }

--- a/UnitTests/expected/Storyboards-All-Defaults.swift.out
+++ b/UnitTests/expected/Storyboards-All-Defaults.swift.out
@@ -4,7 +4,7 @@ import Foundation
 import UIKit
 
 protocol StoryboardSceneType {
-  static var storyboardName : String { get }
+  static var storyboardName: String { get }
 }
 
 extension StoryboardSceneType {
@@ -26,19 +26,19 @@ extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == Str
   }
 }
 
-protocol StoryboardSegueType : RawRepresentable { }
+protocol StoryboardSegueType: RawRepresentable { }
 
 extension UIViewController {
-  func performSegue<S : StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
     performSegueWithIdentifier(segue.rawValue, sender: sender)
   }
 }
 
 struct StoryboardScene {
-  enum Anonymous : StoryboardSceneType {
+  enum Anonymous: StoryboardSceneType {
     static let storyboardName = "Anonymous"
   }
-  enum Dependency : String, StoryboardSceneType {
+  enum Dependency: String, StoryboardSceneType {
     static let storyboardName = "Dependency"
 
     case Dependent = "Dependent"
@@ -46,7 +46,7 @@ struct StoryboardScene {
       return StoryboardScene.Dependency.Dependent.viewController()
     }
   }
-  enum Message : String, StoryboardSceneType {
+  enum Message: String, StoryboardSceneType {
     static let storyboardName = "Message"
 
     case Composer = "Composer"
@@ -69,7 +69,7 @@ struct StoryboardScene {
       return StoryboardScene.Message.URLChooser.viewController() as! XXPickerViewController
     }
   }
-  enum Placeholder : String, StoryboardSceneType {
+  enum Placeholder: String, StoryboardSceneType {
     static let storyboardName = "Placeholder"
 
     case Navigation = "Navigation"
@@ -77,7 +77,7 @@ struct StoryboardScene {
       return StoryboardScene.Placeholder.Navigation.viewController() as! UINavigationController
     }
   }
-  enum Wizard : String, StoryboardSceneType {
+  enum Wizard: String, StoryboardSceneType {
     static let storyboardName = "Wizard"
 
     case Accept_CGU = "Accept-CGU"
@@ -103,13 +103,13 @@ struct StoryboardScene {
 }
 
 struct StoryboardSegue {
-  enum Message : String, StoryboardSegueType {
+  enum Message: String, StoryboardSegueType {
     case CustomBack = "CustomBack"
     case Embed = "Embed"
     case NonCustom = "NonCustom"
     case Show_NavCtrl = "Show-NavCtrl"
   }
-  enum Wizard : String, StoryboardSegueType {
+  enum Wizard: String, StoryboardSegueType {
     case ShowPassword = "ShowPassword"
   }
 }

--- a/UnitTests/expected/Storyboards-Anonymous-Defaults.swift.out
+++ b/UnitTests/expected/Storyboards-Anonymous-Defaults.swift.out
@@ -4,7 +4,7 @@ import Foundation
 import UIKit
 
 protocol StoryboardSceneType {
-  static var storyboardName : String { get }
+  static var storyboardName: String { get }
 }
 
 extension StoryboardSceneType {
@@ -26,16 +26,16 @@ extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == Str
   }
 }
 
-protocol StoryboardSegueType : RawRepresentable { }
+protocol StoryboardSegueType: RawRepresentable { }
 
 extension UIViewController {
-  func performSegue<S : StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
     performSegueWithIdentifier(segue.rawValue, sender: sender)
   }
 }
 
 struct StoryboardScene {
-  enum Anonymous : StoryboardSceneType {
+  enum Anonymous: StoryboardSceneType {
     static let storyboardName = "Anonymous"
   }
 }

--- a/UnitTests/expected/Storyboards-Empty.swift.out
+++ b/UnitTests/expected/Storyboards-Empty.swift.out
@@ -4,7 +4,7 @@ import Foundation
 import UIKit
 
 protocol StoryboardSceneType {
-  static var storyboardName : String { get }
+  static var storyboardName: String { get }
 }
 
 extension StoryboardSceneType {
@@ -26,10 +26,10 @@ extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == Str
   }
 }
 
-protocol StoryboardSegueType : RawRepresentable { }
+protocol StoryboardSegueType: RawRepresentable { }
 
 extension UIViewController {
-  func performSegue<S : StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
     performSegueWithIdentifier(segue.rawValue, sender: sender)
   }
 }

--- a/UnitTests/expected/Storyboards-Message-Defaults.swift.out
+++ b/UnitTests/expected/Storyboards-Message-Defaults.swift.out
@@ -4,7 +4,7 @@ import Foundation
 import UIKit
 
 protocol StoryboardSceneType {
-  static var storyboardName : String { get }
+  static var storyboardName: String { get }
 }
 
 extension StoryboardSceneType {
@@ -26,16 +26,16 @@ extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == Str
   }
 }
 
-protocol StoryboardSegueType : RawRepresentable { }
+protocol StoryboardSegueType: RawRepresentable { }
 
 extension UIViewController {
-  func performSegue<S : StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
     performSegueWithIdentifier(segue.rawValue, sender: sender)
   }
 }
 
 struct StoryboardScene {
-  enum Message : String, StoryboardSceneType {
+  enum Message: String, StoryboardSceneType {
     static let storyboardName = "Message"
 
     case Composer = "Composer"
@@ -61,7 +61,7 @@ struct StoryboardScene {
 }
 
 struct StoryboardSegue {
-  enum Message : String, StoryboardSegueType {
+  enum Message: String, StoryboardSegueType {
     case CustomBack = "CustomBack"
     case Embed = "Embed"
     case NonCustom = "NonCustom"

--- a/UnitTests/expected/Storyboards-Message-Lowercase.swift.out
+++ b/UnitTests/expected/Storyboards-Message-Lowercase.swift.out
@@ -4,7 +4,7 @@ import Foundation
 import UIKit
 
 protocol StoryboardSceneType {
-  static var storyboardName : String { get }
+  static var storyboardName: String { get }
 }
 
 extension StoryboardSceneType {
@@ -26,16 +26,16 @@ extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == Str
   }
 }
 
-protocol StoryboardSegueType : RawRepresentable { }
+protocol StoryboardSegueType: RawRepresentable { }
 
 extension UIViewController {
-  func performSegue<S : StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
     performSegueWithIdentifier(segue.rawValue, sender: sender)
   }
 }
 
 struct StoryboardScene {
-  enum Message : String, StoryboardSceneType {
+  enum Message: String, StoryboardSceneType {
     static let storyboardName = "Message"
 
     case composer = "Composer"
@@ -61,7 +61,7 @@ struct StoryboardScene {
 }
 
 struct StoryboardSegue {
-  enum Message : String, StoryboardSegueType {
+  enum Message: String, StoryboardSegueType {
     case CustomBack = "CustomBack"
     case Embed = "Embed"
     case NonCustom = "NonCustom"

--- a/UnitTests/expected/Strings-Entries-Defaults.swift.out
+++ b/UnitTests/expected/Strings-Entries-Defaults.swift.out
@@ -9,10 +9,10 @@ enum L10n {
   case Greetings(String, Int)
 }
 
-extension L10n : CustomStringConvertible {
-  var description : String { return self.string }
+extension L10n: CustomStringConvertible {
+  var description: String { return self.string }
 
-  var string : String {
+  var string: String {
     switch self {
       case .Title:
         return L10n.tr("Title")

--- a/UnitTests/expected/Strings-File-CustomName.swift.out
+++ b/UnitTests/expected/Strings-File-CustomName.swift.out
@@ -17,10 +17,10 @@ enum XCTLoc {
   case ObjectOwnership(Int, String, String)
 }
 
-extension XCTLoc : CustomStringConvertible {
-  var description : String { return self.string }
+extension XCTLoc: CustomStringConvertible {
+  var description: String { return self.string }
 
-  var string : String {
+  var string: String {
     switch self {
       case .AlertTitle:
         return XCTLoc.tr("alert_title")

--- a/UnitTests/expected/Strings-File-Defaults.swift.out
+++ b/UnitTests/expected/Strings-File-Defaults.swift.out
@@ -17,10 +17,10 @@ enum L10n {
   case ObjectOwnership(Int, String, String)
 }
 
-extension L10n : CustomStringConvertible {
-  var description : String { return self.string }
+extension L10n: CustomStringConvertible {
+  var description: String { return self.string }
 
-  var string : String {
+  var string: String {
     switch self {
       case .AlertTitle:
         return L10n.tr("alert_title")

--- a/UnitTests/expected/Strings-File-UTF8-Defaults.swift.out
+++ b/UnitTests/expected/Strings-File-UTF8-Defaults.swift.out
@@ -17,10 +17,10 @@ enum L10n {
   case ObjectOwnership(Int, String, String)
 }
 
-extension L10n : CustomStringConvertible {
-  var description : String { return self.string }
+extension L10n: CustomStringConvertible {
+  var description: String { return self.string }
 
-  var string : String {
+  var string: String {
     switch self {
       case .AlertTitle:
         return L10n.tr("alert_title")

--- a/UnitTests/expected/Strings-Lines-Defaults.swift.out
+++ b/UnitTests/expected/Strings-Lines-Defaults.swift.out
@@ -9,10 +9,10 @@ enum L10n {
   case GreetingsAndAge(String, Int)
 }
 
-extension L10n : CustomStringConvertible {
-  var description : String { return self.string }
+extension L10n: CustomStringConvertible {
+  var description: String { return self.string }
 
-  var string : String {
+  var string: String {
     switch self {
       case .AppTitle:
         return L10n.tr("AppTitle")

--- a/templates/colors-rawValue.stencil
+++ b/templates/colors-rawValue.stencil
@@ -15,7 +15,7 @@ extension UIColor {
 
 {% if colors %}
 extension UIColor {
-  enum {{enumName|swiftIdentifier}} : UInt32 {
+  enum {{enumName|swiftIdentifier}}: UInt32 {
     {% for color in colors %}
     /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#{{color.rgb}}"></span>
     /// Alpha: {{color.alpha|hexToInt|int255toFloat|percent}} <br/> (0x{{color.rgba}})

--- a/templates/images-allvalues.stencil
+++ b/templates/images-allvalues.stencil
@@ -5,7 +5,7 @@ import Foundation
 import UIKit
 
 extension UIImage {
-  enum {{enumName}} : String {
+  enum {{enumName}}: String {
     {% for image in images %}
     case {{image|swiftIdentifier}} = "{{image}}"
     {% endfor %}

--- a/templates/images-default.stencil
+++ b/templates/images-default.stencil
@@ -5,7 +5,7 @@ import Foundation
 import UIKit
 
 extension UIImage {
-  enum {{enumName}} : String {
+  enum {{enumName}}: String {
     {% for image in images %}
     case {{image|swiftIdentifier}} = "{{image}}"
     {% endfor %}

--- a/templates/storyboards-default.stencil
+++ b/templates/storyboards-default.stencil
@@ -5,7 +5,7 @@ import UIKit
 
 {# This first part of the code is static, same every time whatever Storyboard you have #}
 protocol StoryboardSceneType {
-  static var storyboardName : String { get }
+  static var storyboardName: String { get }
 }
 
 extension StoryboardSceneType {
@@ -27,10 +27,10 @@ extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == Str
   }
 }
 
-protocol StoryboardSegueType : RawRepresentable { }
+protocol StoryboardSegueType: RawRepresentable { }
 
 extension UIViewController {
-  func performSegue<S : StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
     performSegueWithIdentifier(segue.rawValue, sender: sender)
   }
 }
@@ -41,7 +41,7 @@ struct {{sceneEnumName}} {
   {% for storyboard in storyboards %}
   {% set storyboardName %}{{storyboard.name|swiftIdentifier}}{% endset %}
   {% if storyboard.scenes %}
-  enum {{storyboardName}} : String, StoryboardSceneType {
+  enum {{storyboardName}}: String, StoryboardSceneType {
     static let storyboardName = "{{storyboard.name}}"
     {% for scene in storyboard.scenes %}
     {% set sceneID %}{{scene.identifier|swiftIdentifier}}{% endset %}
@@ -59,7 +59,7 @@ struct {{sceneEnumName}} {
     {% endfor %}
   }
   {% else %}
-  enum {{storyboardName}} : StoryboardSceneType {
+  enum {{storyboardName}}: StoryboardSceneType {
     static let storyboardName = "{{storyboard.name}}"
   }
   {% endif %}
@@ -68,7 +68,7 @@ struct {{sceneEnumName}} {
 
 struct {{segueEnumName}} {
   {% for storyboard in storyboards %}{% if storyboard.segues %}
-  enum {{storyboard.name|swiftIdentifier}} : String, StoryboardSegueType {
+  enum {{storyboard.name|swiftIdentifier}}: String, StoryboardSegueType {
     {% for segue in storyboard.segues %}
     case {{segue.identifier|swiftIdentifier}} = "{{segue.identifier}}"
     {% endfor %}

--- a/templates/storyboards-lowercase.stencil
+++ b/templates/storyboards-lowercase.stencil
@@ -5,7 +5,7 @@ import UIKit
 
 {# This first part of the code is static, same every time whatever Storyboard you have #}
 protocol StoryboardSceneType {
-  static var storyboardName : String { get }
+  static var storyboardName: String { get }
 }
 
 extension StoryboardSceneType {
@@ -27,10 +27,10 @@ extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == Str
   }
 }
 
-protocol StoryboardSegueType : RawRepresentable { }
+protocol StoryboardSegueType: RawRepresentable { }
 
 extension UIViewController {
-  func performSegue<S : StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
     performSegueWithIdentifier(segue.rawValue, sender: sender)
   }
 }
@@ -41,7 +41,7 @@ struct {{sceneEnumName}} {
   {% for storyboard in storyboards %}
   {% set storyboardName %}{{storyboard.name|swiftIdentifier}}{% endset %}
   {% if storyboard.scenes %}
-  enum {{storyboardName}} : String, StoryboardSceneType {
+  enum {{storyboardName}}: String, StoryboardSceneType {
     static let storyboardName = "{{storyboard.name}}"
     {% for scene in storyboard.scenes %}
     {% set sceneID %}{{scene.identifier|swiftIdentifier|lowerFirstWord}}{% endset %}
@@ -59,7 +59,7 @@ struct {{sceneEnumName}} {
     {% endfor %}
   }
   {% else %}
-  enum {{storyboardName}} : StoryboardSceneType {
+  enum {{storyboardName}}: StoryboardSceneType {
     static let storyboardName = "{{storyboard.name}}"
   }
   {% endif %}
@@ -68,7 +68,7 @@ struct {{sceneEnumName}} {
 
 struct {{segueEnumName}} {
   {% for storyboard in storyboards %}{% if storyboard.segues %}
-  enum {{storyboard.name|swiftIdentifier}} : String, StoryboardSegueType {
+  enum {{storyboard.name|swiftIdentifier}}: String, StoryboardSegueType {
     {% for segue in storyboard.segues %}
     case {{segue.identifier|swiftIdentifier}} = "{{segue.identifier}}"
     {% endfor %}

--- a/templates/strings-default.stencil
+++ b/templates/strings-default.stencil
@@ -10,10 +10,10 @@ enum {{enumName}} {
   {% endfor %}
 }
 
-extension {{enumName}} : CustomStringConvertible {
-  var description : String { return self.string }
+extension {{enumName}}: CustomStringConvertible {
+  var description: String { return self.string }
 
-  var string : String {
+  var string: String {
     switch self {
       {% for string in strings %}
       {% if string.params %}


### PR DESCRIPTION
To use SwiftGen in tandem with [SwiftLint](https://github.com/realm/SwiftLint) the colons on `strings-default.stencil`, `storyboards-default.stencil` and `images-default.stencil` need to be updated to remove the prefixing space.

I realise this is a trivial improvement, but will reduce compiler warnings when used with SwiftLint!

![storyboard stencil](http://i.imgur.com/Sgpa9xy.png "storyboard stencil")
![image stencil](http://i.imgur.com/BcAsRmi.png "image stencil")

Pull request recreated after Master was updated. [Old Pull Request](https://github.com/AliSoftware/SwiftGen/pull/78)