### PR TITLE
Add SwiftLint to build script

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,5 @@
+disabled_rules: # rule identifiers to exclude from running
+  - force_try
+  - force_cast
+excluded: # paths to ignore during linting. Takes precedence over `included`.
+  - Pods

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,7 @@
 disabled_rules: # rule identifiers to exclude from running
   - force_try
   - force_cast
+  - variable_name 
+
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Pods

--- a/SwiftGen.xcodeproj/project.pbxproj
+++ b/SwiftGen.xcodeproj/project.pbxproj
@@ -357,6 +357,7 @@
 				09A87B3E1BCC9B8000D9B9F5 /* Frameworks */,
 				09A87B3F1BCC9B8000D9B9F5 /* CopyFiles */,
 				1B796448B0837DA367438799 /* Copy Pods Resources */,
+				59962C4A1C39D38A00F68B7A /* SwiftLint */,
 			);
 			buildRules = (
 			);
@@ -519,6 +520,20 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-UnitTests/Pods-UnitTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
+		};
+		59962C4A1C39D38A00F68B7A /* SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = SwiftLint;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\necho \"SwiftLint does not exist, download from https://github.com/realm/SwiftLint\"\nfi";
 		};
 		B84C81A87A5797C0960C5265 /* Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/swiftgen-cli/main.swift
+++ b/swiftgen-cli/main.swift
@@ -12,7 +12,6 @@ import PathKit
 
 let TEMPLATES_RELATIVE_PATH = "../templates"
 
-
 func templateOption(prefix: String) -> Option<String> {
   return Option<String>("template", "default", flag: "t", description: "The name of the template to use for code generation (without the \"\(prefix)\" prefix nor extension).")
 }


### PR DESCRIPTION
As discussed in #79 and [here](https://github.com/AliSoftware/SwiftGen/pull/79#issuecomment-168542621), adding SwiftLint as a build script will reduce regression SwiftLint errors. This build script does check the entire SwiftGen project and I've added the following exclusions (to the `.swiftlint.yml` file) with the following reasons:

```
disabled_rules: 
  - force_try
  - force_cast 
  - variable_name 
```

* force_try - Used in some unit tests to create `result` objects
* force_cast - Used [here](https://github.com/AliSoftware/SwiftGen/blob/master/GenumKit/Stencil/SwiftIdentifier.swift#L71) and [here](https://github.com/AliSoftware/SwiftGen/blob/master/SwiftGen.playground/Pages/Storyboards-Demo.xcplaygroundpage/Contents.swift#L56)
* variable_name - Used sensibly [here](https://github.com/AliSoftware/SwiftGen/blob/master/swiftgen-cli/main.swift#L13)
