### PR TITLE
Don't write unchanged contents to file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ---
 ## Master
 
+#### Enhancements
+
+* Fixed build loop by changing SwiftGen to only write to the output file if the generated code is different from the file contents.
+  [Mathias Nagler](https://github.com/mathiasnagler), [#90](https://github.com/AliSoftware/SwiftGen/pull/90)
+
 #### Fixes
 
 * Fixed typos in code and descriptions: _instanciate_ -> _instantiate_. Please note that the default template used for storyboards `storyboards-default.stencil` had to be modified, so make sure to update your codebase accordingly.  
@@ -188,7 +193,7 @@ Considered to be the first cleaned-up version, far from finished but really usab
 * Introducing `SwiftGenColorEnumBuilder`
 * `swiftgen-colors` CLI
 * Added ability to choose indentation
-* 
+*
 
 ## 0.0.3
 
@@ -208,4 +213,3 @@ Initial version:
 * Mostly testing stuff in a playground
 * Introducing `SwiftGenAssetsEnumBuilder` class
 * `swiftgen-assets` CLI
-

--- a/swiftgen-cli/ArgumentsUtils.swift
+++ b/swiftgen-cli/ArgumentsUtils.swift
@@ -47,6 +47,10 @@ enum OutputDestination: ArgumentConvertible {
     }
   }
 
+  func writeIfChanged(content: String) {
+    write(content, onlyIfChanged: true)
+  }
+  
   func write(content: String, onlyIfChanged: Bool = false) {
     switch self {
     case .Console:

--- a/swiftgen-cli/ArgumentsUtils.swift
+++ b/swiftgen-cli/ArgumentsUtils.swift
@@ -47,12 +47,16 @@ enum OutputDestination: ArgumentConvertible {
     }
   }
 
-  func write(content: String) {
+  func write(content: String, onlyIfChanged: Bool = false) {
     switch self {
     case .Console:
       print(content)
     case .File(let path):
       do {
+        if try path.isContentEqualTo(content) && onlyIfChanged {
+          print("Skipping write as content is unchanged")
+          return
+        }
         try path.write(content)
         print("File written: \(path)")
       } catch let e as NSError {

--- a/swiftgen-cli/ArgumentsUtils.swift
+++ b/swiftgen-cli/ArgumentsUtils.swift
@@ -46,10 +46,6 @@ enum OutputDestination: ArgumentConvertible {
     case .File(let path): return path.description
     }
   }
-
-  func writeIfChanged(content: String) {
-    write(content, onlyIfChanged: true)
-  }
   
   func write(content: String, onlyIfChanged: Bool = false) {
     switch self {

--- a/swiftgen-cli/ArgumentsUtils.swift
+++ b/swiftgen-cli/ArgumentsUtils.swift
@@ -53,9 +53,8 @@ enum OutputDestination: ArgumentConvertible {
       print(content)
     case .File(let path):
       do {
-        if try path.isContentEqualTo(content) && onlyIfChanged {
-          print("Skipping write as content is unchanged")
-          return
+        if try onlyIfChanged && path.read(NSUTF8StringEncoding) == content {
+          return print("Not writing the file as content is unchanged")
         }
         try path.write(content)
         print("File written: \(path)")
@@ -63,15 +62,6 @@ enum OutputDestination: ArgumentConvertible {
         print("Error: \(e)")
       }
     }
-  }
-}
-
-// MARK: Change comparsion
-
-extension Path {
-  func isContentEqualTo(string: String) throws -> Bool {
-    let content = try read(NSUTF8StringEncoding)
-    return content == string
   }
 }
 

--- a/swiftgen-cli/ArgumentsUtils.swift
+++ b/swiftgen-cli/ArgumentsUtils.swift
@@ -62,6 +62,15 @@ enum OutputDestination: ArgumentConvertible {
   }
 }
 
+// MARK: Change comparsion
+
+extension Path {
+  func isContentEqualTo(string: String) throws -> Bool {
+    let content = try read(NSUTF8StringEncoding)
+    return content == string
+  }
+}
+
 // MARK: Template Arguments
 
 enum TemplateError: ErrorType, CustomStringConvertible {

--- a/swiftgen-cli/ArgumentsUtils.swift
+++ b/swiftgen-cli/ArgumentsUtils.swift
@@ -53,7 +53,7 @@ enum OutputDestination: ArgumentConvertible {
       print(content)
     case .File(let path):
       do {
-        if try onlyIfChanged && path.read(NSUTF8StringEncoding) == content {
+        if try path.exists && onlyIfChanged && path.read(NSUTF8StringEncoding) == content {
           return print("Not writing the file as content is unchanged")
         }
         try path.write(content)

--- a/swiftgen-cli/colors.swift
+++ b/swiftgen-cli/colors.swift
@@ -34,7 +34,7 @@ let colorsCommand = command(
     let template = try GenumTemplate(path: templateRealPath)
     let context = parser.stencilContext(enumName: enumName)
     let rendered = try template.render(context)
-    output.writeIfChanged(rendered)
+    output.write(rendered, onlyIfChanged: true)
   } catch {
     print("Failed to render template \(error)")
   }

--- a/swiftgen-cli/colors.swift
+++ b/swiftgen-cli/colors.swift
@@ -34,7 +34,7 @@ let colorsCommand = command(
     let template = try GenumTemplate(path: templateRealPath)
     let context = parser.stencilContext(enumName: enumName)
     let rendered = try template.render(context)
-    output.write(rendered)
+    output.writeIfChanged(rendered)
   } catch {
     print("Failed to render template \(error)")
   }

--- a/swiftgen-cli/images.swift
+++ b/swiftgen-cli/images.swift
@@ -22,7 +22,7 @@ let imagesCommand = command(
     let template = try GenumTemplate(path: templateRealPath)
     let context = parser.stencilContext(enumName: enumName)
     let rendered = try template.render(context)
-    output.writeIfChanged(rendered)
+    output.write(rendered, onlyIfChanged: true)
   } catch {
     print("Failed to render template \(error)")
   }

--- a/swiftgen-cli/images.swift
+++ b/swiftgen-cli/images.swift
@@ -22,7 +22,7 @@ let imagesCommand = command(
     let template = try GenumTemplate(path: templateRealPath)
     let context = parser.stencilContext(enumName: enumName)
     let rendered = try template.render(context)
-    output.write(rendered)
+    output.writeIfChanged(rendered)
   } catch {
     print("Failed to render template \(error)")
   }

--- a/swiftgen-cli/storyboards.swift
+++ b/swiftgen-cli/storyboards.swift
@@ -27,7 +27,7 @@ let storyboardsCommand = command(
     let template = try GenumTemplate(path: templateRealPath)
     let context = parser.stencilContext(sceneEnumName: sceneEnumName, segueEnumName: segueEnumName)
     let rendered = try template.render(context)
-    output.writeIfChanged(rendered)
+    output.write(rendered, onlyIfChanged: true)
   } catch {
     print("Failed to render template \(error)")
   }

--- a/swiftgen-cli/storyboards.swift
+++ b/swiftgen-cli/storyboards.swift
@@ -27,7 +27,7 @@ let storyboardsCommand = command(
     let template = try GenumTemplate(path: templateRealPath)
     let context = parser.stencilContext(sceneEnumName: sceneEnumName, segueEnumName: segueEnumName)
     let rendered = try template.render(context)
-    output.write(rendered)
+    output.writeIfChanged(rendered)
   } catch {
     print("Failed to render template \(error)")
   }

--- a/swiftgen-cli/strings.swift
+++ b/swiftgen-cli/strings.swift
@@ -23,7 +23,7 @@ let stringsCommand = command(
     let template = try GenumTemplate(path: templateRealPath)
     let context = parser.stencilContext(enumName: enumName, tableName: path.lastComponentWithoutExtension)
     let rendered = try template.render(context)
-    output.writeIfChanged(rendered)
+    output.write(rendered, onlyIfChanged: true)
   } catch let error as NSError {
     print("Error: \(error.localizedDescription)")
   }

--- a/swiftgen-cli/strings.swift
+++ b/swiftgen-cli/strings.swift
@@ -23,7 +23,7 @@ let stringsCommand = command(
     let template = try GenumTemplate(path: templateRealPath)
     let context = parser.stencilContext(enumName: enumName, tableName: path.lastComponentWithoutExtension)
     let rendered = try template.render(context)
-    output.write(rendered)
+    output.writeIfChanged(rendered)
   } catch let error as NSError {
     print("Error: \(error.localizedDescription)")
   }


### PR DESCRIPTION
Currently, `swiftgen` will always write the generated content to the `--output` file. This also happens when the generated content is exactly equal to what is already contained in the output file. 

Xcode will pick up the "change" regardless of the content and this behaviour can lead to build loops, especially when using `IBInspectable` and `IBDesignable`.

I changed `write:` to take a second parameter `onlyIfChanged:` that controls wether the generated content will be written to a file if it is exactly the same as already in the file. I also changed commands `strings`, `storyboards`, `images` and `colors` to use the new behaviour.

This idea was also discussed in #89.