### PR TITLE
fix misplacement in playground files

### DIFF
--- a/SwiftGen.playground/Pages/Colors-Demo.xcplaygroundpage/Contents.swift
+++ b/SwiftGen.playground/Pages/Colors-Demo.xcplaygroundpage/Contents.swift
@@ -46,10 +46,9 @@ extension UIColor {
 }
 
 
+//: #### Usage Example
 
-
-UICol//: #### Usage Example
-or(named: .ArticleTitle)
+UIColor(named: .ArticleTitle)
 UIColor(named: .ArticleBody)
 UIColor(named: .ArticleBody)
 UIColor(named: .Translucent)

--- a/SwiftGen.playground/Pages/Storyboards-Demo.xcplaygroundpage/Contents.swift
+++ b/SwiftGen.playground/Pages/Storyboards-Demo.xcplaygroundpage/Contents.swift
@@ -83,8 +83,9 @@ struct StoryboardSegue {
 }
 
 
-let initialVC = StoryboardScene.Wiz//: #### Usage Example
-ard.initialViewController()
+//: #### Usage Example
+
+let initialVC = StoryboardScene.Wizard.initialViewController()
 initialVC.title
 
 let validateVC = StoryboardScene.Wizard.ValidatePassword.viewController()

--- a/SwiftGen.playground/Pages/Strings-Demo.xcplaygroundpage/Contents.swift
+++ b/SwiftGen.playground/Pages/Strings-Demo.xcplaygroundpage/Contents.swift
@@ -51,10 +51,9 @@ func tr(key: L10n) -> String {
 }
 
 
+//: #### Usage example
 
-
-let ale//: #### Usage example
-rtTitle = tr(.AlertTitle)
+let alertTitle = tr(.AlertTitle)
 let hello1 = tr(.Greetings("David", 29))
 let hello2 = L10n.Greetings("Olivier", 32) // Prints as a string in the console because it's CustomStringConvertible
 


### PR DESCRIPTION
The header text was misplaced and some examples didn't work therefore.