### PR TITLE
Show translation as documentation

### DIFF
--- a/UnitTests/expected/Strings-Entries-Defaults.swift.out
+++ b/UnitTests/expected/Strings-Entries-Defaults.swift.out
@@ -3,9 +3,13 @@
 import Foundation
 
 enum L10n {
-  /// My awesome title
+  /**
+    My awesome title
+  */
   case Title
-  /// Hello, my name is %@ and I'm %d
+  /**
+    Hello, my name is %@ and I'm %d
+  */
   case Greetings(String, Int)
 }
 

--- a/UnitTests/expected/Strings-File-CustomName.swift.out
+++ b/UnitTests/expected/Strings-File-CustomName.swift.out
@@ -3,17 +3,29 @@
 import Foundation
 
 enum XCTLoc {
-  /// Title of the alert
+  /**
+    Title of the alert
+  */
   case AlertTitle
-  /// Some alert body there
+  /**
+    Some alert body there
+  */
   case AlertMessage
-  /// Hello, my name is %@ and I'm %d
+  /**
+    Hello, my name is %@ and I'm %d
+  */
   case Greetings(String, Int)
-  /// You have %d apples
+  /**
+    You have %d apples
+  */
   case ApplesCount(Int)
-  /// Those %d bananas belong to %@.
+  /**
+    Those %d bananas belong to %@.
+  */
   case BananasOwner(Int, String)
-  /// These are %3$@'s %1$d %2$@.
+  /**
+    These are %3$@'s %1$d %2$@.
+  */
   case ObjectOwnership(Int, String, String)
 }
 

--- a/UnitTests/expected/Strings-File-Defaults.swift.out
+++ b/UnitTests/expected/Strings-File-Defaults.swift.out
@@ -3,17 +3,29 @@
 import Foundation
 
 enum L10n {
-  /// Title of the alert
+  /**
+    Title of the alert
+  */
   case AlertTitle
-  /// Some alert body there
+  /**
+    Some alert body there
+  */
   case AlertMessage
-  /// Hello, my name is %@ and I'm %d
+  /**
+    Hello, my name is %@ and I'm %d
+  */
   case Greetings(String, Int)
-  /// You have %d apples
+  /**
+    You have %d apples
+  */
   case ApplesCount(Int)
-  /// Those %d bananas belong to %@.
+  /**
+    Those %d bananas belong to %@.
+  */
   case BananasOwner(Int, String)
-  /// These are %3$@'s %1$d %2$@.
+  /**
+    These are %3$@'s %1$d %2$@.
+  */
   case ObjectOwnership(Int, String, String)
 }
 

--- a/UnitTests/expected/Strings-File-UTF8-Defaults.swift.out
+++ b/UnitTests/expected/Strings-File-UTF8-Defaults.swift.out
@@ -3,17 +3,29 @@
 import Foundation
 
 enum L10n {
-  /// Titre de l'alerte
+  /**
+    Titre de l'alerte
+  */
   case AlertTitle
-  /// Contenu détaillé de l'alerte
+  /**
+    Contenu détaillé de l'alerte
+  */
   case AlertMessage
-  /// Bonjour, mon nom est %@ et j'ai %d ans
+  /**
+    Bonjour, mon nom est %@ et j'ai %d ans
+  */
   case Greetings(String, Int)
-  /// Vous avez %d pommes
+  /**
+    Vous avez %d pommes
+  */
   case ApplesCount(Int)
-  /// Ces %d bananes appartiennent à %@.
+  /**
+    Ces %d bananes appartiennent à %@.
+  */
   case BananasOwner(Int, String)
-  /// Ce sont les %1$d %2$@ de %3$@.
+  /**
+    Ce sont les %1$d %2$@ de %3$@.
+  */
   case ObjectOwnership(Int, String, String)
 }
 

--- a/UnitTests/expected/Strings-Lines-Defaults.swift.out
+++ b/UnitTests/expected/Strings-Lines-Defaults.swift.out
@@ -3,9 +3,13 @@
 import Foundation
 
 enum L10n {
-  /// My awesome title
+  /**
+    My awesome title
+  */
   case AppTitle
-  /// My name is %@, I am %d
+  /**
+    My name is %@, I am %d
+  */
   case GreetingsAndAge(String, Int)
 }
 

--- a/templates/strings-default.stencil
+++ b/templates/strings-default.stencil
@@ -5,7 +5,9 @@ import Foundation
 
 enum {{enumName}} {
   {% for string in strings %}
-  /// {{string.translation}}
+  /**
+    {{string.translation}}
+  */
   case {{string.key|swiftIdentifier|snakeToCamelCase}}{% if string.params %}({{string.params.types|join}}){% endif %}
   {% endfor %}
 }


### PR DESCRIPTION
Hi,

this small patch changes documentation for strings, allowing to do `Opt + Click` in any translation and show there the current translation as you can see in the image below.

![screen shot 2016-05-09 at 11 00 28](https://cloud.githubusercontent.com/assets/701909/15108309/8b9a4b98-15d5-11e6-82f6-ac08f1a7f72b.png)

This is useful because sometimes keys aren't enough explanatory.

**PD:** I'm not sure if this should be translated to other templates (storyboards, images...), so I'll wait to your feeling about that to do too.