### PR TITLE
Storyboard templates for OS X

### DIFF
--- a/SwiftGen.xcodeproj/project.pbxproj
+++ b/SwiftGen.xcodeproj/project.pbxproj
@@ -85,6 +85,10 @@
 		E2B1F5841D0272A10000E40A /* storyboards-osx-default.stencil in Resources */ = {isa = PBXBuildFile; fileRef = E2B1F5831D0272A10000E40A /* storyboards-osx-default.stencil */; };
 		E2B1F5861D0272CF0000E40A /* Storyboards-osx-Anonymous-Defaults.swift.out in Resources */ = {isa = PBXBuildFile; fileRef = E2B1F5851D0272CF0000E40A /* Storyboards-osx-Anonymous-Defaults.swift.out */; };
 		E2B1F5881D0274B90000E40A /* Storyboards-osx-Empty.swift.out in Resources */ = {isa = PBXBuildFile; fileRef = E2B1F5871D0274B90000E40A /* Storyboards-osx-Empty.swift.out */; };
+		E2B1F58C1D0282460000E40A /* Placeholder-osx.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E2B1F58B1D0282460000E40A /* Placeholder-osx.storyboard */; };
+		E2B1F58E1D02824D0000E40A /* Dependency-osx.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E2B1F58D1D02824D0000E40A /* Dependency-osx.storyboard */; };
+		E2B1F5901D02832F0000E40A /* Message-osx.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E2B1F58F1D02832F0000E40A /* Message-osx.storyboard */; };
+		E2B1F5961D0287CF0000E40A /* Storyboards-osx-Message-Defaults.swift.out in Resources */ = {isa = PBXBuildFile; fileRef = E2B1F5951D0287CF0000E40A /* Storyboards-osx-Message-Defaults.swift.out */; };
 		EFFE62F41C27073700FE9783 /* Placeholder.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EFFE62F31C27073700FE9783 /* Placeholder.storyboard */; };
 		EFFE62F81C27081A00FE9783 /* Dependency.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EFFE62F71C27081A00FE9783 /* Dependency.storyboard */; };
 		F24DA0455755C4EC4F1DDD96 /* Pods_swiftgen.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC28A16A3F1852C832A3B47E /* Pods_swiftgen.framework */; };
@@ -225,6 +229,10 @@
 		E2B1F5831D0272A10000E40A /* storyboards-osx-default.stencil */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "storyboards-osx-default.stencil"; sourceTree = "<group>"; };
 		E2B1F5851D0272CF0000E40A /* Storyboards-osx-Anonymous-Defaults.swift.out */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Storyboards-osx-Anonymous-Defaults.swift.out"; sourceTree = "<group>"; };
 		E2B1F5871D0274B90000E40A /* Storyboards-osx-Empty.swift.out */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Storyboards-osx-Empty.swift.out"; sourceTree = "<group>"; };
+		E2B1F58B1D0282460000E40A /* Placeholder-osx.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = "Placeholder-osx.storyboard"; sourceTree = "<group>"; };
+		E2B1F58D1D02824D0000E40A /* Dependency-osx.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = "Dependency-osx.storyboard"; sourceTree = "<group>"; };
+		E2B1F58F1D02832F0000E40A /* Message-osx.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = "Message-osx.storyboard"; sourceTree = "<group>"; };
+		E2B1F5951D0287CF0000E40A /* Storyboards-osx-Message-Defaults.swift.out */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Storyboards-osx-Message-Defaults.swift.out"; sourceTree = "<group>"; };
 		E5E15CBE3901E2C7C3240E93 /* Pods_UnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EFFE62F31C27073700FE9783 /* Placeholder.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Placeholder.storyboard; sourceTree = "<group>"; };
 		EFFE62F71C27081A00FE9783 /* Dependency.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Dependency.storyboard; sourceTree = "<group>"; };
@@ -314,11 +322,14 @@
 			children = (
 				09030C2F1B6D4F8500275BF5 /* Images.xcassets */,
 				09030C0B1B6D30E800275BF5 /* Message.storyboard */,
+				E2B1F58F1D02832F0000E40A /* Message-osx.storyboard */,
 				09030C0C1B6D30E800275BF5 /* Wizard.storyboard */,
 				470A14E81BEA6CF10052EAC8 /* Anonymous.storyboard */,
 				E2B1F5811D0272560000E40A /* Anonymous-osx.storyboard */,
 				EFFE62F31C27073700FE9783 /* Placeholder.storyboard */,
+				E2B1F58B1D0282460000E40A /* Placeholder-osx.storyboard */,
 				EFFE62F71C27081A00FE9783 /* Dependency.storyboard */,
+				E2B1F58D1D02824D0000E40A /* Dependency-osx.storyboard */,
 				09030C1D1B6D473E00275BF5 /* colors.txt */,
 				641CD33D1C3AE35A00D7FED9 /* colors.clr */,
 				097504261C78ED3400D1A01B /* colors.xml */,
@@ -405,6 +416,7 @@
 				4761E0341BDE753000B9B05F /* Storyboards-Empty.swift.out */,
 				E2B1F5871D0274B90000E40A /* Storyboards-osx-Empty.swift.out */,
 				09EB0A261BDC60F000B2CF79 /* Storyboards-Message-Defaults.swift.out */,
+				E2B1F5951D0287CF0000E40A /* Storyboards-osx-Message-Defaults.swift.out */,
 				470A14E21BEA641E0052EAC8 /* Storyboards-Message-Lowercase.swift.out */,
 				470A14EA1BEA6DAB0052EAC8 /* Storyboards-Anonymous-Defaults.swift.out */,
 				E2B1F5851D0272CF0000E40A /* Storyboards-osx-Anonymous-Defaults.swift.out */,
@@ -579,6 +591,7 @@
 				09EB0A1A1BDC3AC400B2CF79 /* strings-default.stencil in Resources */,
 				09EB0A291BDC60F000B2CF79 /* Colors-List-Defaults.swift.out in Resources */,
 				09A87B701BCCA5F600D9B9F5 /* Strings-Lines-Defaults.swift.out in Resources */,
+				E2B1F5961D0287CF0000E40A /* Storyboards-osx-Message-Defaults.swift.out in Resources */,
 				47CB53331CFC0B2100AA19C0 /* SFNSDisplay-Bold.otf in Resources */,
 				4761E0361BDE753000B9B05F /* Colors-Empty.swift.out in Resources */,
 				EFFE62F81C27081A00FE9783 /* Dependency.storyboard in Resources */,
@@ -599,6 +612,7 @@
 				4761E0371BDE753000B9B05F /* Images-Empty.swift.out in Resources */,
 				4761E0391BDE753000B9B05F /* Strings-Empty.swift.out in Resources */,
 				470A14E91BEA6CF10052EAC8 /* Anonymous.storyboard in Resources */,
+				E2B1F5901D02832F0000E40A /* Message-osx.storyboard in Resources */,
 				47CB53431CFC175100AA19C0 /* strings-swift3.stencil in Resources */,
 				47CB53391CFC0B2100AA19C0 /* ZapfDingbats.ttf in Resources */,
 				09A87B711BCCA5FC00D9B9F5 /* Localizable.strings in Resources */,
@@ -609,6 +623,7 @@
 				09EB0A311BDC8F4100B2CF79 /* LocUTF8.strings in Resources */,
 				E2B1F5841D0272A10000E40A /* storyboards-osx-default.stencil in Resources */,
 				47CB53381CFC0B2100AA19C0 /* SFNSText-Regular.otf in Resources */,
+				E2B1F58E1D02824D0000E40A /* Dependency-osx.storyboard in Resources */,
 				09EB0A2E1BDC60F000B2CF79 /* Storyboards-All-Defaults.swift.out in Resources */,
 				470A14E61BEA68C40052EAC8 /* Images-File-AllValues.swift.out in Resources */,
 				E2B1F5821D0272560000E40A /* Anonymous-osx.storyboard in Resources */,
@@ -618,6 +633,7 @@
 				0911503F1BD4136E00EBC803 /* storyboards-default.stencil in Resources */,
 				097504271C78ED3400D1A01B /* colors.xml in Resources */,
 				47CB53341CFC0B2100AA19C0 /* SFNSDisplay-Heavy.otf in Resources */,
+				E2B1F58C1D0282460000E40A /* Placeholder-osx.storyboard in Resources */,
 				470A14E11BEA63D30052EAC8 /* storyboards-lowercase.stencil in Resources */,
 				47CB53421CFC175100AA19C0 /* storyboards-swift3.stencil in Resources */,
 				93DA731D1BF34E26000A3C84 /* Strings-File-UTF8-Defaults.swift.out in Resources */,

--- a/SwiftGen.xcodeproj/project.pbxproj
+++ b/SwiftGen.xcodeproj/project.pbxproj
@@ -81,6 +81,10 @@
 		C25A54321CEE7C2200401BE5 /* Colors-Txt-File-Defaults.swift.out in Resources */ = {isa = PBXBuildFile; fileRef = C25A54311CEE7C2200401BE5 /* Colors-Txt-File-Defaults.swift.out */; };
 		C25A54341CEE7CEB00401BE5 /* Colors-Txt-File-CustomName.swift.out in Resources */ = {isa = PBXBuildFile; fileRef = C25A54331CEE7CEB00401BE5 /* Colors-Txt-File-CustomName.swift.out */; };
 		C2DBEADE1C8F87AD00E62C9E /* FontsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2DBEADD1C8F87AD00E62C9E /* FontsTests.swift */; };
+		E2B1F5821D0272560000E40A /* Anonymous-osx.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E2B1F5811D0272560000E40A /* Anonymous-osx.storyboard */; };
+		E2B1F5841D0272A10000E40A /* storyboards-osx-default.stencil in Resources */ = {isa = PBXBuildFile; fileRef = E2B1F5831D0272A10000E40A /* storyboards-osx-default.stencil */; };
+		E2B1F5861D0272CF0000E40A /* Storyboards-osx-Anonymous-Defaults.swift.out in Resources */ = {isa = PBXBuildFile; fileRef = E2B1F5851D0272CF0000E40A /* Storyboards-osx-Anonymous-Defaults.swift.out */; };
+		E2B1F5881D0274B90000E40A /* Storyboards-osx-Empty.swift.out in Resources */ = {isa = PBXBuildFile; fileRef = E2B1F5871D0274B90000E40A /* Storyboards-osx-Empty.swift.out */; };
 		EFFE62F41C27073700FE9783 /* Placeholder.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EFFE62F31C27073700FE9783 /* Placeholder.storyboard */; };
 		EFFE62F81C27081A00FE9783 /* Dependency.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EFFE62F71C27081A00FE9783 /* Dependency.storyboard */; };
 		F24DA0455755C4EC4F1DDD96 /* Pods_swiftgen.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC28A16A3F1852C832A3B47E /* Pods_swiftgen.framework */; };
@@ -217,6 +221,10 @@
 		C25A54331CEE7CEB00401BE5 /* Colors-Txt-File-CustomName.swift.out */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Colors-Txt-File-CustomName.swift.out"; sourceTree = "<group>"; };
 		C2DBEADD1C8F87AD00E62C9E /* FontsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FontsTests.swift; sourceTree = "<group>"; };
 		E0542E32A906407325456A56 /* Pods-swiftgen.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-swiftgen.release.xcconfig"; path = "Pods/Target Support Files/Pods-swiftgen/Pods-swiftgen.release.xcconfig"; sourceTree = "<group>"; };
+		E2B1F5811D0272560000E40A /* Anonymous-osx.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = "Anonymous-osx.storyboard"; sourceTree = "<group>"; };
+		E2B1F5831D0272A10000E40A /* storyboards-osx-default.stencil */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "storyboards-osx-default.stencil"; sourceTree = "<group>"; };
+		E2B1F5851D0272CF0000E40A /* Storyboards-osx-Anonymous-Defaults.swift.out */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Storyboards-osx-Anonymous-Defaults.swift.out"; sourceTree = "<group>"; };
+		E2B1F5871D0274B90000E40A /* Storyboards-osx-Empty.swift.out */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Storyboards-osx-Empty.swift.out"; sourceTree = "<group>"; };
 		E5E15CBE3901E2C7C3240E93 /* Pods_UnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EFFE62F31C27073700FE9783 /* Placeholder.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Placeholder.storyboard; sourceTree = "<group>"; };
 		EFFE62F71C27081A00FE9783 /* Dependency.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Dependency.storyboard; sourceTree = "<group>"; };
@@ -308,6 +316,7 @@
 				09030C0B1B6D30E800275BF5 /* Message.storyboard */,
 				09030C0C1B6D30E800275BF5 /* Wizard.storyboard */,
 				470A14E81BEA6CF10052EAC8 /* Anonymous.storyboard */,
+				E2B1F5811D0272560000E40A /* Anonymous-osx.storyboard */,
 				EFFE62F31C27073700FE9783 /* Placeholder.storyboard */,
 				EFFE62F71C27081A00FE9783 /* Dependency.storyboard */,
 				09030C1D1B6D473E00275BF5 /* colors.txt */,
@@ -329,6 +338,7 @@
 				091150351BD3274E00EBC803 /* images-default.stencil */,
 				470A14E41BEA68630052EAC8 /* images-allvalues.stencil */,
 				0911503E1BD4053D00EBC803 /* storyboards-default.stencil */,
+				E2B1F5831D0272A10000E40A /* storyboards-osx-default.stencil */,
 				471D92121C43F65300D8EA69 /* storyboards-uppercase.stencil */,
 				470A14E01BEA63D30052EAC8 /* storyboards-lowercase.stencil */,
 				47CB533A1CFC16FE00AA19C0 /* storyboards-swift3.stencil */,
@@ -393,9 +403,11 @@
 			isa = PBXGroup;
 			children = (
 				4761E0341BDE753000B9B05F /* Storyboards-Empty.swift.out */,
+				E2B1F5871D0274B90000E40A /* Storyboards-osx-Empty.swift.out */,
 				09EB0A261BDC60F000B2CF79 /* Storyboards-Message-Defaults.swift.out */,
 				470A14E21BEA641E0052EAC8 /* Storyboards-Message-Lowercase.swift.out */,
 				470A14EA1BEA6DAB0052EAC8 /* Storyboards-Anonymous-Defaults.swift.out */,
+				E2B1F5851D0272CF0000E40A /* Storyboards-osx-Anonymous-Defaults.swift.out */,
 				09EB0A251BDC60F000B2CF79 /* Storyboards-All-Defaults.swift.out */,
 				09EB0A241BDC60F000B2CF79 /* Storyboards-All-CustomName.swift.out */,
 				47CB533C1CFC170E00AA19C0 /* Storyboards-Anonymous-Swift3.swift.out */,
@@ -580,6 +592,7 @@
 				09A87B6C1BCCA5F600D9B9F5 /* Strings-Entries-Defaults.swift.out in Resources */,
 				C24AFD0A1C924188005FE3EF /* Fonts-File-Empty.swift.out in Resources */,
 				0911503B1BD3ECAE00EBC803 /* colors-default.stencil in Resources */,
+				E2B1F5881D0274B90000E40A /* Storyboards-osx-Empty.swift.out in Resources */,
 				09A87B6D1BCCA5F600D9B9F5 /* Strings-File-Defaults.swift.out in Resources */,
 				09EB0A2A1BDC60F000B2CF79 /* Images-Entries-Defaults.swift.out in Resources */,
 				09A87B6E1BCCA5F600D9B9F5 /* Strings-File-CustomName.swift.out in Resources */,
@@ -592,10 +605,13 @@
 				EFFE62F41C27073700FE9783 /* Placeholder.storyboard in Resources */,
 				47CB533E1CFC170E00AA19C0 /* Storyboards-Anonymous-Swift3.swift.out in Resources */,
 				09EB0A281BDC60F000B2CF79 /* Colors-File-Defaults.swift.out in Resources */,
+				E2B1F5861D0272CF0000E40A /* Storyboards-osx-Anonymous-Defaults.swift.out in Resources */,
 				09EB0A311BDC8F4100B2CF79 /* LocUTF8.strings in Resources */,
+				E2B1F5841D0272A10000E40A /* storyboards-osx-default.stencil in Resources */,
 				47CB53381CFC0B2100AA19C0 /* SFNSText-Regular.otf in Resources */,
 				09EB0A2E1BDC60F000B2CF79 /* Storyboards-All-Defaults.swift.out in Resources */,
 				470A14E61BEA68C40052EAC8 /* Images-File-AllValues.swift.out in Resources */,
+				E2B1F5821D0272560000E40A /* Anonymous-osx.storyboard in Resources */,
 				47CB53321CFC0B2100AA19C0 /* SFNSDisplay-Black.otf in Resources */,
 				09EB0A2D1BDC60F000B2CF79 /* Storyboards-All-CustomName.swift.out in Resources */,
 				09EB0A271BDC60F000B2CF79 /* Colors-File-CustomName.swift.out in Resources */,

--- a/UnitTests/TestSuites/StoryboardTests.swift
+++ b/UnitTests/TestSuites/StoryboardTests.swift
@@ -104,3 +104,30 @@ class StoryboardTests: XCTestCase {
     XCTDiffStrings(result, expected)
   }
 }
+
+// MARK: OS X StoryboardTests
+
+extension StoryboardTests {
+  
+  func testOSXEmpty() {
+    let parser = StoryboardParser()
+    
+    let template = GenumTemplate(templateString: fixtureString("storyboards-osx-default.stencil"))
+    let result = try! template.render(parser.stencilContext())
+    
+    let expected = self.fixtureString("Storyboards-osx-Empty.swift.out")
+    XCTDiffStrings(result, expected)
+  }
+  
+  func testOSXAnonymousStoryboardWithDefaults() {
+    let parser = StoryboardParser()
+    parser.addStoryboardAtPath(self.fixturePath("Anonymous-osx.storyboard"))
+    
+    let template = GenumTemplate(templateString: fixtureString("storyboards-osx-default.stencil"))
+    let result = try! template.render(parser.stencilContext())
+    
+    let expected = self.fixtureString("Storyboards-osx-Anonymous-Defaults.swift.out")
+    XCTDiffStrings(result, expected)
+  }
+ 
+}

--- a/UnitTests/TestSuites/StoryboardTests.swift
+++ b/UnitTests/TestSuites/StoryboardTests.swift
@@ -119,6 +119,17 @@ extension StoryboardTests {
     XCTDiffStrings(result, expected)
   }
   
+  func testOSXMessageStoryboardWithDefaults() {
+    let parser = StoryboardParser()
+    parser.addStoryboardAtPath(self.fixturePath("Message-osx.storyboard"))
+    
+    let template = GenumTemplate(templateString: fixtureString("storyboards-osx-default.stencil"))
+    let result = try! template.render(parser.stencilContext())
+    
+    let expected = self.fixtureString("Storyboards-osx-Message-Defaults.swift.out")
+    XCTDiffStrings(result, expected)
+  }
+  
   func testOSXAnonymousStoryboardWithDefaults() {
     let parser = StoryboardParser()
     parser.addStoryboardAtPath(self.fixturePath("Anonymous-osx.storyboard"))

--- a/UnitTests/expected/Storyboards-osx-Anonymous-Defaults.swift.out
+++ b/UnitTests/expected/Storyboards-osx-Anonymous-Defaults.swift.out
@@ -12,17 +12,17 @@ extension StoryboardSceneType {
     return NSStoryboard(name: self.storyboardName, bundle: nil)
   }
 
-  static func initialViewController() -> AnyObject {
+  static func initialController() -> AnyObject {
     return storyboard().instantiateInitialController()!
   }
 }
 
 extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == String {
-  func viewController() -> AnyObject {
+  func controller() -> AnyObject {
     return Self.storyboard().instantiateControllerWithIdentifier(self.rawValue)
   }
-  static func viewController(identifier: Self) -> AnyObject {
-    return identifier.viewController()
+  static func controller(identifier: Self) -> AnyObject {
+    return identifier.controller()
   }
 }
 

--- a/UnitTests/expected/Storyboards-osx-Anonymous-Defaults.swift.out
+++ b/UnitTests/expected/Storyboards-osx-Anonymous-Defaults.swift.out
@@ -1,0 +1,50 @@
+// Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen
+
+import Foundation
+import Cocoa
+
+protocol StoryboardSceneType {
+  static var storyboardName: String { get }
+}
+
+extension StoryboardSceneType {
+  static func storyboard() -> NSStoryboard {
+    return NSStoryboard(name: self.storyboardName, bundle: nil)
+  }
+
+  static func initialViewController() -> AnyObject {
+    return storyboard().instantiateInitialController()!
+  }
+}
+
+extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == String {
+  func viewController() -> AnyObject {
+    return Self.storyboard().instantiateControllerWithIdentifier(self.rawValue)
+  }
+  static func viewController(identifier: Self) -> AnyObject {
+    return identifier.viewController()
+  }
+}
+
+protocol StoryboardSegueType: RawRepresentable { }
+
+extension NSWindowController {
+  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+    performSegueWithIdentifier(segue.rawValue, sender: sender)
+  }
+}
+
+extension NSViewController {
+  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+    performSegueWithIdentifier(segue.rawValue, sender: sender)
+  }
+}
+
+struct StoryboardScene {
+  enum Anonymous_Osx: StoryboardSceneType {
+    static let storyboardName = "Anonymous-osx"
+  }
+}
+
+struct StoryboardSegue {
+}

--- a/UnitTests/expected/Storyboards-osx-Empty.swift.out
+++ b/UnitTests/expected/Storyboards-osx-Empty.swift.out
@@ -12,17 +12,17 @@ extension StoryboardSceneType {
     return NSStoryboard(name: self.storyboardName, bundle: nil)
   }
 
-  static func initialViewController() -> AnyObject {
+  static func initialController() -> AnyObject {
     return storyboard().instantiateInitialController()!
   }
 }
 
 extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == String {
-  func viewController() -> AnyObject {
+  func controller() -> AnyObject {
     return Self.storyboard().instantiateControllerWithIdentifier(self.rawValue)
   }
-  static func viewController(identifier: Self) -> AnyObject {
-    return identifier.viewController()
+  static func controller(identifier: Self) -> AnyObject {
+    return identifier.controller()
   }
 }
 

--- a/UnitTests/expected/Storyboards-osx-Empty.swift.out
+++ b/UnitTests/expected/Storyboards-osx-Empty.swift.out
@@ -1,0 +1,43 @@
+// Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen
+
+import Foundation
+import Cocoa
+
+protocol StoryboardSceneType {
+  static var storyboardName: String { get }
+}
+
+extension StoryboardSceneType {
+  static func storyboard() -> NSStoryboard {
+    return NSStoryboard(name: self.storyboardName, bundle: nil)
+  }
+
+  static func initialViewController() -> AnyObject {
+    return storyboard().instantiateInitialController()!
+  }
+}
+
+extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == String {
+  func viewController() -> AnyObject {
+    return Self.storyboard().instantiateControllerWithIdentifier(self.rawValue)
+  }
+  static func viewController(identifier: Self) -> AnyObject {
+    return identifier.viewController()
+  }
+}
+
+protocol StoryboardSegueType: RawRepresentable { }
+
+extension NSWindowController {
+  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+    performSegueWithIdentifier(segue.rawValue, sender: sender)
+  }
+}
+
+extension NSViewController {
+  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+    performSegueWithIdentifier(segue.rawValue, sender: sender)
+  }
+}
+
+// No storyboard found

--- a/UnitTests/expected/Storyboards-osx-Message-Defaults.swift.out
+++ b/UnitTests/expected/Storyboards-osx-Message-Defaults.swift.out
@@ -1,0 +1,88 @@
+// Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen
+
+import Foundation
+import Cocoa
+
+protocol StoryboardSceneType {
+  static var storyboardName: String { get }
+}
+
+extension StoryboardSceneType {
+  static func storyboard() -> NSStoryboard {
+    return NSStoryboard(name: self.storyboardName, bundle: nil)
+  }
+
+  static func initialController() -> AnyObject {
+    return storyboard().instantiateInitialController()!
+  }
+}
+
+extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == String {
+  func controller() -> AnyObject {
+    return Self.storyboard().instantiateControllerWithIdentifier(self.rawValue)
+  }
+  static func controller(identifier: Self) -> AnyObject {
+    return identifier.controller()
+  }
+}
+
+protocol StoryboardSegueType: RawRepresentable { }
+
+extension NSWindowController {
+  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+    performSegueWithIdentifier(segue.rawValue, sender: sender)
+  }
+}
+
+extension NSViewController {
+  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+    performSegueWithIdentifier(segue.rawValue, sender: sender)
+  }
+}
+
+struct StoryboardScene {
+  enum Message_Osx: String, StoryboardSceneType {
+    static let storyboardName = "Message-osx"
+
+    case MessageDetailsScene = "MessageDetails"
+    static func instantiateMessageDetails() -> NSViewController {
+      return StoryboardScene.Message_Osx.MessageDetailsScene.controller()
+    }
+
+    case MessageListScene = "MessageList"
+    static func instantiateMessageList() -> NSViewController {
+      return StoryboardScene.Message_Osx.MessageListScene.controller()
+    }
+
+    case MessageListFooterScene = "MessageListFooter"
+    static func instantiateMessageListFooter() -> NSViewController {
+      return StoryboardScene.Message_Osx.MessageListFooterScene.controller()
+    }
+
+    case MessagesTabScene = "MessagesTab"
+    static func instantiateMessagesTab() -> NSTabViewController {
+      return StoryboardScene.Message_Osx.MessagesTabScene.controller() as! NSTabViewController
+    }
+
+    case SplitMessagesScene = "SplitMessages"
+    static func instantiateSplitMessages() -> NSSplitViewController {
+      return StoryboardScene.Message_Osx.SplitMessagesScene.controller() as! NSSplitViewController
+    }
+
+    case WindowCtrlScene = "WindowCtrl"
+    static func instantiateWindowCtrl() -> NSWindowController {
+      return StoryboardScene.Message_Osx.WindowCtrlScene.controller() as! NSWindowController
+    }
+  }
+}
+
+struct StoryboardSegue {
+  enum Message_Osx: String, StoryboardSegueType {
+    case Custom = "Custom"
+    case Embed = "Embed"
+    case Modal = "Modal"
+    case Popover = "Popover"
+    case Sheet = "Sheet"
+    case Show = "Show"
+  }
+}

--- a/UnitTests/fixtures/Anonymous-osx.storyboard
+++ b/UnitTests/fixtures/Anonymous-osx.storyboard
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
+    </dependencies>
+    <scenes>
+        <!--Window Controller-->
+        <scene sceneID="Dbo-xl-Peq">
+            <objects>
+                <windowController id="1P9-6c-uvR" sceneMemberID="viewController">
+                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="b0r-9x-PfB">
+                        <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+                        <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+                        <rect key="contentRect" x="163" y="199" width="480" height="270"/>
+                        <rect key="screenRect" x="0.0" y="0.0" width="1280" height="777"/>
+                    </window>
+                    <connections>
+                        <segue destination="QQb-OV-IBg" kind="relationship" relationship="window.shadowedContentViewController" id="Ics-Wd-Vef"/>
+                    </connections>
+                </windowController>
+                <customObject id="emQ-ax-yLV" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-29" y="140"/>
+        </scene>
+        <!--Split View Controller-->
+        <scene sceneID="mil-Re-aUn">
+            <objects>
+                <splitViewController id="QQb-OV-IBg" sceneMemberID="viewController">
+                    <splitViewItems>
+                        <splitViewItem id="H8O-U7-guB"/>
+                        <splitViewItem id="dgf-qA-Mpo"/>
+                    </splitViewItems>
+                    <splitView key="splitView" dividerStyle="thin" vertical="YES" id="HmC-Pa-hEf">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </splitView>
+                    <connections>
+                        <segue destination="R2f-4N-xbc" kind="relationship" relationship="splitItems" id="X6W-e9-Enk"/>
+                        <segue destination="cIf-as-pTF" kind="relationship" relationship="splitItems" id="zs1-Tk-SMT"/>
+                    </connections>
+                </splitViewController>
+                <customObject id="6kQ-pC-l9L" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="549" y="135"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="io5-dC-RpZ">
+            <objects>
+                <viewController id="R2f-4N-xbc" sceneMemberID="viewController">
+                    <view key="view" id="ovi-QT-pQu">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Fpq-6S-0QY">
+                                <rect key="frame" x="46" y="142" width="358" height="17"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="None of the scenes in this storyboard have a StoryboardID" placeholderString="" id="m9F-ea-7i7">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="Fpq-6S-0QY" firstAttribute="centerX" secondItem="ovi-QT-pQu" secondAttribute="centerX" id="co4-4H-1Qq"/>
+                            <constraint firstItem="Fpq-6S-0QY" firstAttribute="centerY" secondItem="ovi-QT-pQu" secondAttribute="centerY" id="n7L-ih-p4O"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <customObject id="w5a-0R-Snz" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1219" y="-61"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="tr7-gS-RI6">
+            <objects>
+                <viewController id="cIf-as-pTF" sceneMemberID="viewController">
+                    <view key="view" id="gUc-vx-Io9">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Wfo-Pi-7oP">
+                                <rect key="frame" x="46" y="142" width="358" height="17"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="None of the scenes in this storyboard have a StoryboardID" placeholderString="" id="Xwr-dR-UkL">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="Wfo-Pi-7oP" firstAttribute="centerX" secondItem="gUc-vx-Io9" secondAttribute="centerX" id="MEJ-RE-Q2O"/>
+                            <constraint firstItem="Wfo-Pi-7oP" firstAttribute="centerY" secondItem="gUc-vx-Io9" secondAttribute="centerY" id="e2V-6t-4dt"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <customObject id="rLU-3f-8Fh" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1219" y="297"/>
+        </scene>
+    </scenes>
+</document>

--- a/UnitTests/fixtures/Anonymous.storyboard
+++ b/UnitTests/fixtures/Anonymous.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="Da7-nc-Egy">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="Da7-nc-Egy">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <scenes>
         <!--Root View Controller-->
@@ -12,27 +12,23 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="M0F-O9-0mb">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="ReuseCellID" id="X89-VJ-CSC">
                                 <rect key="frame" x="0.0" y="92" width="600" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="X89-VJ-CSC" id="bHj-5x-yL6">
-                                    <rect key="frame" x="0.0" y="0.0" width="600" height="44"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xCe-DM-Qbf">
                                             <rect key="frame" x="32" y="11" width="42" height="21"/>
-                                            <animations/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
-                                    <animations/>
                                 </tableViewCellContentView>
-                                <animations/>
                                 <connections>
                                     <segue destination="r7F-4h-qXH" kind="show" id="mVk-VC-mC4"/>
                                 </connections>
@@ -63,13 +59,11 @@
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="None of the scenes in this storyboard have a StoryboardID" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="faN-z0-vo4">
                                 <rect key="frame" x="77" y="289" width="446" height="21"/>
-                                <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="faN-z0-vo4" firstAttribute="centerX" secondItem="AVR-KD-uTn" secondAttribute="centerX" id="8Jj-Zt-srm"/>
@@ -88,7 +82,6 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="23U-NI-pcd">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <animations/>
                     </navigationBar>
                     <connections>
                         <segue destination="tSI-oM-AEY" kind="relationship" relationship="rootViewController" id="ymq-ah-cp2"/>

--- a/UnitTests/fixtures/Dependency-osx.storyboard
+++ b/UnitTests/fixtures/Dependency-osx.storyboard
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="fqQ-GK-ec1">
+            <objects>
+                <viewController storyboardIdentifier="Dependent" id="4Nl-Le-vww" sceneMemberID="viewController">
+                    <view key="view" id="EWX-Kc-EdI">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </view>
+                </viewController>
+                <customObject id="xt3-NN-Sx7" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="323" y="394"/>
+        </scene>
+    </scenes>
+</document>

--- a/UnitTests/fixtures/Message-osx.storyboard
+++ b/UnitTests/fixtures/Message-osx.storyboard
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
+    </dependencies>
+    <scenes>
+        <!--Window Controller-->
+        <scene sceneID="cOe-wK-5aS">
+            <objects>
+                <windowController storyboardIdentifier="WindowCtrl" id="iTF-24-C42" sceneMemberID="viewController">
+                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="7kg-xf-23M">
+                        <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+                        <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+                        <rect key="contentRect" x="163" y="199" width="480" height="270"/>
+                        <rect key="screenRect" x="0.0" y="0.0" width="1280" height="777"/>
+                    </window>
+                    <connections>
+                        <segue destination="8Pf-JJ-Bj4" kind="relationship" relationship="window.shadowedContentViewController" id="zxt-bS-Xji"/>
+                    </connections>
+                </windowController>
+                <customObject id="R45-VF-O9D" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="702" y="186"/>
+        </scene>
+        <!--Split View Controller-->
+        <scene sceneID="4rE-a5-G8R">
+            <objects>
+                <splitViewController storyboardIdentifier="SplitMessages" id="8Pf-JJ-Bj4" sceneMemberID="viewController">
+                    <splitViewItems>
+                        <splitViewItem id="bhe-yp-fVo"/>
+                        <splitViewItem id="TOh-gG-pLp"/>
+                    </splitViewItems>
+                    <splitView key="splitView" dividerStyle="thin" vertical="YES" id="wqk-6g-2UY">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </splitView>
+                    <connections>
+                        <segue destination="3pk-bw-FlH" kind="relationship" relationship="splitItems" id="3ZF-gt-7HJ"/>
+                        <segue destination="Lxj-cP-fFs" kind="relationship" relationship="splitItems" id="RKO-gC-l69"/>
+                    </connections>
+                </splitViewController>
+                <customObject id="XQl-Fb-usV" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1260" y="179"/>
+        </scene>
+        <!--Tab View Controller-->
+        <scene sceneID="KL7-WW-1Vf">
+            <objects>
+                <tabViewController storyboardIdentifier="MessagesTab" id="3pk-bw-FlH" sceneMemberID="viewController">
+                    <tabViewItems>
+                        <tabViewItem id="cKo-D7-dmH"/>
+                    </tabViewItems>
+                    <tabView key="tabView" type="noTabsNoBorder" id="mqV-o4-mzq">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <font key="font" metaFont="message"/>
+                        <tabViewItems/>
+                    </tabView>
+                    <connections>
+                        <segue destination="JyP-8A-Iz9" kind="relationship" relationship="tabItems" id="ToA-vU-P69"/>
+                    </connections>
+                </tabViewController>
+                <customObject id="IrZ-i8-MpX" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1952" y="400"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="GeB-EV-NfO">
+            <objects>
+                <viewController storyboardIdentifier="MessageDetails" id="Lxj-cP-fFs" sceneMemberID="viewController">
+                    <view key="view" id="Kr5-Lg-sHR">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="VfK-Tf-7Nk">
+                                <rect key="frame" x="48" y="205" width="354" height="85"/>
+                                <textFieldCell key="cell" controlSize="mini" sendsActionOnEndEditing="YES" id="cRx-JR-wmP">
+                                    <font key="font" metaFont="system"/>
+                                    <string key="title">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. </string>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                                <connections>
+                                    <segue destination="F1C-uo-ozY" kind="custom" identifier="Custom" id="and-Oo-071"/>
+                                </connections>
+                            </textField>
+                        </subviews>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="VfK-Tf-7Nk" secondAttribute="trailing" constant="50" id="1op-SA-a0O"/>
+                            <constraint firstItem="VfK-Tf-7Nk" firstAttribute="top" secondItem="Kr5-Lg-sHR" secondAttribute="top" constant="10" id="J76-Hl-yQV"/>
+                            <constraint firstItem="VfK-Tf-7Nk" firstAttribute="leading" secondItem="Kr5-Lg-sHR" secondAttribute="leading" constant="50" id="Xe6-81-gj9"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <segue destination="F1C-uo-ozY" kind="popover" identifier="Popover" popoverBehavior="t" preferredEdge="maxY" id="flp-DG-HKm"/>
+                        <segue destination="F1C-uo-ozY" kind="modal" identifier="Modal" id="v1X-lb-nhi"/>
+                        <segue destination="F1C-uo-ozY" kind="sheet" identifier="Sheet" id="Kxp-Ra-zsP"/>
+                        <segue destination="F1C-uo-ozY" kind="show" identifier="Show" id="zL6-jB-uO5"/>
+                    </connections>
+                </viewController>
+                <customObject id="l9k-hF-Sxp" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1946" y="-48"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="QXR-d2-KZV">
+            <objects>
+                <viewController id="gY6-Xv-7Ac" sceneMemberID="viewController">
+                    <view key="view" id="hQI-1R-0r9">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <containerView translatesAutoresizingMaskIntoConstraints="NO" id="sZs-f8-CYX">
+                                <rect key="frame" x="0.0" y="0.0" width="450" height="104"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="104" id="YIM-lJ-sJm"/>
+                                </constraints>
+                                <connections>
+                                    <segue destination="EHq-9a-j15" kind="embed" identifier="Embed" id="bkk-80-yU1"/>
+                                </connections>
+                            </containerView>
+                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="B9t-pY-9Yn">
+                                <rect key="frame" x="18" y="183" width="414" height="34"/>
+                                <textFieldCell key="cell" controlSize="mini" sendsActionOnEndEditing="YES" title="This scene is volontarly unreachable to test that SwiftGen won't generate anything for it" id="aGE-IG-lcQ">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="sZs-f8-CYX" firstAttribute="leading" secondItem="hQI-1R-0r9" secondAttribute="leading" id="3ye-yN-ZnX"/>
+                            <constraint firstItem="B9t-pY-9Yn" firstAttribute="leading" secondItem="hQI-1R-0r9" secondAttribute="leading" constant="20" id="Ta8-ab-xxO"/>
+                            <constraint firstItem="B9t-pY-9Yn" firstAttribute="centerY" secondItem="hQI-1R-0r9" secondAttribute="centerY" constant="-50" id="VB8-lG-0Q1"/>
+                            <constraint firstAttribute="trailing" secondItem="B9t-pY-9Yn" secondAttribute="trailing" constant="20" id="kqg-u7-eV6"/>
+                            <constraint firstAttribute="trailing" secondItem="sZs-f8-CYX" secondAttribute="trailing" id="por-ME-iak"/>
+                            <constraint firstAttribute="bottom" secondItem="sZs-f8-CYX" secondAttribute="bottom" id="qLU-f3-Zkl"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <customObject id="rm2-es-rfG" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2572" y="616"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="LpL-gC-gOa">
+            <objects>
+                <viewController id="F1C-uo-ozY" sceneMemberID="viewController">
+                    <view key="view" id="G3v-66-afC">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </view>
+                </viewController>
+                <customObject id="Wds-af-oJk" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2653" y="-244"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="Qo3-4F-rQr">
+            <objects>
+                <viewController storyboardIdentifier="MessageList" id="JyP-8A-Iz9" sceneMemberID="viewController">
+                    <view key="view" id="CS4-15-wYO">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fo6-MZ-O66">
+                                <rect key="frame" x="0.0" y="100" width="450" height="200"/>
+                                <clipView key="contentView" id="YEe-Ei-AnX">
+                                    <rect key="frame" x="1" y="0.0" width="448" height="199"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" headerView="YSR-S4-q3g" viewBased="YES" id="UbK-3D-yKD">
+                                            <rect key="frame" x="0.0" y="0.0" width="448" height="176"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <size key="intercellSpacing" width="3" height="2"/>
+                                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                                            <tableColumns>
+                                                <tableColumn width="116" minWidth="40" maxWidth="1000" id="sgD-GB-vgl">
+                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                    </tableHeaderCell>
+                                                    <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" title="Text Cell" id="0hi-Ps-z7r">
+                                                        <font key="font" metaFont="system"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                    <prototypeCellViews>
+                                                        <tableCellView id="pad-U1-omO">
+                                                            <rect key="frame" x="1" y="1" width="116" height="17"/>
+                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                            <subviews>
+                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dSN-cP-GI4">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="100" height="17"/>
+                                                                    <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="Xvk-GJ-27q">
+                                                                        <font key="font" metaFont="system"/>
+                                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                            </subviews>
+                                                            <connections>
+                                                                <outlet property="textField" destination="dSN-cP-GI4" id="lmM-iB-CoM"/>
+                                                            </connections>
+                                                        </tableCellView>
+                                                    </prototypeCellViews>
+                                                </tableColumn>
+                                                <tableColumn width="326" minWidth="40" maxWidth="1000" id="Nqi-cU-7HJ">
+                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                    </tableHeaderCell>
+                                                    <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" title="Text Cell" id="X85-uR-Guk">
+                                                        <font key="font" metaFont="system"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                    <prototypeCellViews>
+                                                        <tableCellView id="f02-6E-fWT">
+                                                            <rect key="frame" x="120" y="1" width="326" height="17"/>
+                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                            <subviews>
+                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CM7-eb-Enb">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="100" height="17"/>
+                                                                    <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="oaX-E0-1cJ">
+                                                                        <font key="font" metaFont="system"/>
+                                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                            </subviews>
+                                                            <connections>
+                                                                <outlet property="textField" destination="CM7-eb-Enb" id="JVB-Sk-cui"/>
+                                                            </connections>
+                                                        </tableCellView>
+                                                    </prototypeCellViews>
+                                                </tableColumn>
+                                            </tableColumns>
+                                        </tableView>
+                                    </subviews>
+                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </clipView>
+                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="7Cm-36-PpE">
+                                    <rect key="frame" x="1" y="183" width="448" height="16"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                                <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="00X-BG-5ic">
+                                    <rect key="frame" x="224" y="17" width="15" height="102"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                                <tableHeaderView key="headerView" id="YSR-S4-q3g">
+                                    <rect key="frame" x="0.0" y="0.0" width="448" height="23"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </tableHeaderView>
+                            </scrollView>
+                            <containerView translatesAutoresizingMaskIntoConstraints="NO" id="fXO-6Q-6cr">
+                                <rect key="frame" x="0.0" y="0.0" width="450" height="100"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="100" id="wse-eB-1fP"/>
+                                </constraints>
+                                <connections>
+                                    <segue destination="EHq-9a-j15" kind="embed" identifier="Embed" id="rRd-wB-sdk"/>
+                                </connections>
+                            </containerView>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="fo6-MZ-O66" firstAttribute="leading" secondItem="CS4-15-wYO" secondAttribute="leading" id="CwQ-JW-kwg"/>
+                            <constraint firstItem="fXO-6Q-6cr" firstAttribute="top" secondItem="fo6-MZ-O66" secondAttribute="bottom" id="JFq-Ee-fys"/>
+                            <constraint firstAttribute="trailing" secondItem="fXO-6Q-6cr" secondAttribute="trailing" id="JSc-rW-Nhv"/>
+                            <constraint firstItem="fXO-6Q-6cr" firstAttribute="leading" secondItem="CS4-15-wYO" secondAttribute="leading" id="N8Z-rL-qlx"/>
+                            <constraint firstAttribute="trailing" secondItem="fo6-MZ-O66" secondAttribute="trailing" id="S9b-6y-x8D"/>
+                            <constraint firstAttribute="bottom" secondItem="fXO-6Q-6cr" secondAttribute="bottom" id="kub-fN-9wE"/>
+                            <constraint firstItem="fo6-MZ-O66" firstAttribute="top" secondItem="CS4-15-wYO" secondAttribute="top" id="vb9-LB-P48"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <customObject id="EPR-3G-ldC" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2572" y="249"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="7qj-eQ-e3S">
+            <objects>
+                <viewController storyboardIdentifier="MessageListFooter" id="EHq-9a-j15" sceneMemberID="viewController">
+                    <view key="view" id="udM-Wg-2Vg">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </view>
+                </viewController>
+                <customObject id="Jav-rW-TmU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3180" y="433"/>
+        </scene>
+    </scenes>
+    <inferredMetricsTieBreakers>
+        <segue reference="zL6-jB-uO5"/>
+        <segue reference="rRd-wB-sdk"/>
+    </inferredMetricsTieBreakers>
+</document>

--- a/UnitTests/fixtures/Message.storyboard
+++ b/UnitTests/fixtures/Message.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="xKD-v4-X1W">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="xKD-v4-X1W">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <scenes>
         <!--Home-->
@@ -16,7 +16,6 @@
                     <view key="view" contentMode="scaleToFill" id="RUy-Co-Dta">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     </view>
                     <connections>
@@ -41,7 +40,6 @@
                         <subviews>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QUC-4f-CaG">
                                 <rect key="frame" x="20" y="28" width="560" height="506"/>
-                                <animations/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -52,7 +50,6 @@
                             </textView>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="im2-gZ-zaz">
                                 <rect key="frame" x="20" y="562" width="46" height="30"/>
-                                <animations/>
                                 <state key="normal" title="Button"/>
                                 <connections>
                                     <segue destination="xKD-v4-X1W" kind="custom" identifier="CustomBack" customClass="CustomSegueClass2" id="eBb-AQ-abV"/>
@@ -60,13 +57,11 @@
                             </button>
                             <containerView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jfg-zf-vVo">
                                 <rect key="frame" x="180" y="472" width="240" height="128"/>
-                                <animations/>
                                 <connections>
                                     <segue destination="TKc-dv-ThZ" kind="embed" identifier="Embed" id="O2Q-vy-SWs"/>
                                 </connections>
                             </containerView>
                         </subviews>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     </view>
                 </viewController>
@@ -85,7 +80,6 @@
                     <view key="view" contentMode="scaleToFill" id="mjf-Eu-GFg">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     </view>
                     <connections>
@@ -110,20 +104,17 @@
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="T02-7w-iPh">
                                 <rect key="frame" x="180" y="472" width="240" height="128"/>
-                                <animations/>
                                 <connections>
                                     <segue destination="TKc-dv-ThZ" kind="embed" identifier="Embed" id="Ne2-PQ-HKf"/>
                                 </connections>
                             </containerView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This scene is volontarly unreachable to test that SwiftGen won't generate anything for it" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="bRe-yk-AVy">
                                 <rect key="frame" x="115" y="279.5" width="370" height="41"/>
-                                <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="bRe-yk-AVy" firstAttribute="centerY" secondItem="8dI-WY-DPv" secondAttribute="centerY" id="FJZ-AN-fRC"/>
@@ -142,7 +133,6 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="BfC-HV-CpZ">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="CustomMessageCell" id="ABY-1J-cxh">
@@ -151,9 +141,7 @@
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ABY-1J-cxh" id="mGm-Cb-M2O">
                                     <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
-                                    <animations/>
                                 </tableViewCellContentView>
-                                <animations/>
                                 <connections>
                                     <segue destination="fbV-qd-GcD" kind="show" id="x0v-NY-l9l"/>
                                 </connections>
@@ -177,7 +165,6 @@
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="nRP-jO-yPL">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <animations/>
                     </navigationBar>
                     <connections>
                         <segue destination="4eG-UT-EY5" kind="relationship" relationship="rootViewController" id="Z5i-nf-Ukl"/>
@@ -198,7 +185,6 @@
                     <view key="view" contentMode="scaleToFill" id="XWV-Fs-B8e">
                         <rect key="frame" x="0.0" y="0.0" width="240" height="128"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     </view>
                 </viewController>

--- a/UnitTests/fixtures/Placeholder-osx.storyboard
+++ b/UnitTests/fixtures/Placeholder-osx.storyboard
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
+    </dependencies>
+    <scenes>
+        <!--Window Controller-->
+        <scene sceneID="eNa-6E-hop">
+            <objects>
+                <windowController storyboardIdentifier="Window" id="3Gn-1I-HiJ" sceneMemberID="viewController">
+                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="sw7-rd-HiT">
+                        <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+                        <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+                        <rect key="contentRect" x="163" y="199" width="480" height="270"/>
+                        <rect key="screenRect" x="0.0" y="0.0" width="1280" height="777"/>
+                    </window>
+                    <connections>
+                        <segue destination="EIJ-iL-tpR" kind="relationship" relationship="window.shadowedContentViewController" id="wUy-rT-OAp"/>
+                    </connections>
+                </windowController>
+                <customObject id="BHg-iq-dVb" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="262" y="234"/>
+        </scene>
+        <!--Dependency-osx-->
+        <scene sceneID="jeB-5h-7HV">
+            <objects>
+                <controllerPlaceholder storyboardIdentifier="Dependent" storyboardName="Dependency-osx" id="EIJ-iL-tpR" sceneMemberID="viewController"/>
+                <customObject id="s9D-CE-7EV" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="715.5" y="228"/>
+        </scene>
+    </scenes>
+</document>

--- a/UnitTests/fixtures/Wizard.storyboard
+++ b/UnitTests/fixtures/Wizard.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="txY-Mc-CKa">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="txY-Mc-CKa">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <scenes>
         <!--Create-->
@@ -19,14 +19,12 @@
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="k6D-nB-wS1">
                                 <rect key="frame" x="548" y="28" width="32" height="30"/>
-                                <animations/>
                                 <state key="normal" title="Next"/>
                                 <connections>
                                     <segue destination="30h-14-fok" kind="show" identifier="ShowPassword" id="y7o-M4-oge"/>
                                 </connections>
                             </button>
                         </subviews>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="k6D-nB-wS1" firstAttribute="top" secondItem="vW2-yr-H1F" secondAttribute="bottom" constant="8" symbolic="YES" id="G1k-Td-dUp"/>
@@ -49,7 +47,6 @@
                     <view key="view" contentMode="scaleToFill" id="N1u-m6-6Oc">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     </view>
                 </viewController>
@@ -68,7 +65,6 @@
                     <view key="view" contentMode="scaleToFill" id="rJE-c0-6Bp">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     </view>
                 </viewController>
@@ -83,7 +79,6 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="wtR-sc-VB5">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="PrefCell" id="H4k-gA-zIi">
@@ -92,9 +87,7 @@
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="H4k-gA-zIi" id="egQ-bG-uas">
                                     <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
-                                    <animations/>
                                 </tableViewCellContentView>
-                                <animations/>
                             </tableViewCell>
                         </prototypes>
                         <connections>

--- a/templates/storyboards-osx-default.stencil
+++ b/templates/storyboards-osx-default.stencil
@@ -1,0 +1,86 @@
+// Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen
+
+import Foundation
+import Cocoa
+
+{# This first part of the code is static, same every time whatever Storyboard you have #}
+protocol StoryboardSceneType {
+  static var storyboardName: String { get }
+}
+
+extension StoryboardSceneType {
+  static func storyboard() -> NSStoryboard {
+    return NSStoryboard(name: self.storyboardName, bundle: nil)
+  }
+
+  static func initialViewController() -> AnyObject {
+    return storyboard().instantiateInitialController()!
+  }
+}
+
+extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == String {
+  func viewController() -> AnyObject {
+    return Self.storyboard().instantiateControllerWithIdentifier(self.rawValue)
+  }
+  static func viewController(identifier: Self) -> AnyObject {
+    return identifier.viewController()
+  }
+}
+
+protocol StoryboardSegueType: RawRepresentable { }
+
+extension NSWindowController {
+  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+    performSegueWithIdentifier(segue.rawValue, sender: sender)
+  }
+}
+
+extension NSViewController {
+  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+    performSegueWithIdentifier(segue.rawValue, sender: sender)
+  }
+}
+
+{# This is where the generation begins, this code depends on what you have in your Storyboards #}
+{% if storyboards %}
+struct {{sceneEnumName}} {
+  {% for storyboard in storyboards %}
+  {% set storyboardName %}{{storyboard.name|swiftIdentifier}}{% endset %}
+  {% if storyboard.scenes %}
+  enum {{storyboardName}}: String, StoryboardSceneType {
+    static let storyboardName = "{{storyboard.name}}"
+    {% for scene in storyboard.scenes %}
+    {% set sceneID %}{{scene.identifier|swiftIdentifier}}{% endset %}
+
+    case {{sceneID}}Scene = "{{scene.identifier}}"
+    {% if scene.class %}
+    static func instantiate{{sceneID|snakeToCamelCase}}() -> {{scene.class}} {
+      return {{sceneEnumName}}.{{storyboardName}}.{{sceneID}}Scene.viewController() as! {{scene.class}}
+    }
+    {% else %}
+    static func instantiate{{sceneID|snakeToCamelCase}}() -> AnyObject {
+      return {{sceneEnumName}}.{{storyboardName}}.{{sceneID}}Scene.viewController()
+    }
+    {% endif %}
+    {% endfor %}
+  }
+  {% else %}
+  enum {{storyboardName}}: StoryboardSceneType {
+    static let storyboardName = "{{storyboard.name}}"
+  }
+  {% endif %}
+  {% endfor %}
+}
+
+struct {{segueEnumName}} {
+  {% for storyboard in storyboards %}{% if storyboard.segues %}
+  enum {{storyboard.name|swiftIdentifier}}: String, StoryboardSegueType {
+    {% for segue in storyboard.segues %}
+    case {{segue.identifier|swiftIdentifier}} = "{{segue.identifier}}"
+    {% endfor %}
+  }
+  {% endif %}{% endfor %}
+}
+{% else %}
+// No storyboard found
+{% endif %}

--- a/templates/storyboards-osx-default.stencil
+++ b/templates/storyboards-osx-default.stencil
@@ -13,17 +13,17 @@ extension StoryboardSceneType {
     return NSStoryboard(name: self.storyboardName, bundle: nil)
   }
 
-  static func initialViewController() -> AnyObject {
+  static func initialController() -> AnyObject {
     return storyboard().instantiateInitialController()!
   }
 }
 
 extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == String {
-  func viewController() -> AnyObject {
+  func controller() -> AnyObject {
     return Self.storyboard().instantiateControllerWithIdentifier(self.rawValue)
   }
-  static func viewController(identifier: Self) -> AnyObject {
-    return identifier.viewController()
+  static func controller(identifier: Self) -> AnyObject {
+    return identifier.controller()
   }
 }
 
@@ -55,11 +55,11 @@ struct {{sceneEnumName}} {
     case {{sceneID}}Scene = "{{scene.identifier}}"
     {% if scene.class %}
     static func instantiate{{sceneID|snakeToCamelCase}}() -> {{scene.class}} {
-      return {{sceneEnumName}}.{{storyboardName}}.{{sceneID}}Scene.viewController() as! {{scene.class}}
+      return {{sceneEnumName}}.{{storyboardName}}.{{sceneID}}Scene.controller() as! {{scene.class}}
     }
     {% else %}
     static func instantiate{{sceneID|snakeToCamelCase}}() -> AnyObject {
-      return {{sceneEnumName}}.{{storyboardName}}.{{sceneID}}Scene.viewController()
+      return {{sceneEnumName}}.{{storyboardName}}.{{sceneID}}Scene.controller()
     }
     {% endif %}
     {% endfor %}


### PR DESCRIPTION
Following the comment of @toshi0383, I give a second try. This PR is not completed yet, it still missing more examples and advanced use cases. For the example, I have two tests running:
- Empty storyboard template (maybe the most important right now)
- Anonymous storyboard: `NSWindowController` -> `NSSplitViewController` (as window content) -> left view controller / right view controller

Since `instantiateInitialController` and `instantiateControllerWithIdentifier` are returning `AnyObject`, and since `NSWindowController` and `NSViewController` doesn't have any commun parent, the template is returning `AnyObject` too, it will be up to the user to do the cast. I'm not really fan of this, but don't have any elegant solution for now.

In order to keep the useful `performSegue` as iOS, I added an extension on `NSWindowController` as well. I did a quick look on the others controllers available (split, tab...) are inheriting of `NSViewController`.

@toshi0383: what do you think of the output?
@AliSoftware I have `testAllStoryboardsWithCustomName` and `testAllStoryboardsWithDefaults` due to the OS X storyboard. Should we split the storyboards iOS and OS X in two different directories?