### PR TITLE
Add FontConvertible protocol to generated enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   [#125](https://github.com/AliSoftware/SwiftGen/pull/125),
   [#126](https://github.com/AliSoftware/SwiftGen/pull/126),
   [#127](https://github.com/AliSoftware/SwiftGen/pull/127)
+* Added missing FontConvertible protocol conformance to default fonts template.  
+  [Ben Chatelain](https://github.com/phatblat) [#129](https://github.com/AliSoftware/SwiftGen/pull/129)
 
 ## 1.0.0
 

--- a/UnitTests/expected/Fonts-Dir-CustomName.swift.out
+++ b/UnitTests/expected/Fonts-Dir-CustomName.swift.out
@@ -27,18 +27,18 @@ extension Font {
 }
 
 struct CustomFamily {
-  enum SFNSDisplay: String {
+  enum SFNSDisplay: String, FontConvertible {
     case Regular = ".SFNSDisplay-Regular"
     case Heavy = ".SFNSDisplay-Heavy"
     case Black = ".SFNSDisplay-Black"
     case Bold = ".SFNSDisplay-Bold"
   }
-  enum SFNSText: String {
+  enum SFNSText: String, FontConvertible {
     case Heavy = ".SFNSText-Heavy"
     case Bold = ".SFNSText-Bold"
     case Regular = ".SFNSText-Regular"
   }
-  enum ZapfDingbats: String {
+  enum ZapfDingbats: String, FontConvertible {
     case Regular = "ZapfDingbatsITC"
   }
 }

--- a/UnitTests/expected/Fonts-Dir-Default.swift.out
+++ b/UnitTests/expected/Fonts-Dir-Default.swift.out
@@ -27,18 +27,18 @@ extension Font {
 }
 
 struct FontFamily {
-  enum SFNSDisplay: String {
+  enum SFNSDisplay: String, FontConvertible {
     case Regular = ".SFNSDisplay-Regular"
     case Heavy = ".SFNSDisplay-Heavy"
     case Black = ".SFNSDisplay-Black"
     case Bold = ".SFNSDisplay-Bold"
   }
-  enum SFNSText: String {
+  enum SFNSText: String, FontConvertible {
     case Heavy = ".SFNSText-Heavy"
     case Bold = ".SFNSText-Bold"
     case Regular = ".SFNSText-Regular"
   }
-  enum ZapfDingbats: String {
+  enum ZapfDingbats: String, FontConvertible {
     case Regular = "ZapfDingbatsITC"
   }
 }

--- a/templates/fonts-default.stencil
+++ b/templates/fonts-default.stencil
@@ -29,7 +29,7 @@ extension Font {
 
 struct {{enumName}} {
   {% for family in families %}
-  enum {{family.name|swiftIdentifier|snakeToCamelCaseNoPrefix}}: String {
+  enum {{family.name|swiftIdentifier|snakeToCamelCaseNoPrefix}}: String, FontConvertible {
     {% for font in family.fonts %}
     case {{font.style|swiftIdentifier|snakeToCamelCaseNoPrefix}} = "{{font.fontName}}"
     {% endfor %}


### PR DESCRIPTION
Trying out the new font type generation in SwiftGen 1.0 and hit a snag:

![screen shot 2016-06-03 at 10 13 08 pm](https://cloud.githubusercontent.com/assets/28851/15797549/a8e8a2f4-29d9-11e6-9b69-750c123807bf.png)

The one custom font I have in this app is `Apple Symbols.ttc`. Here is the generated code:

```swift
// Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen

import UIKit.UIFont

protocol FontConvertible {
  func font(size: CGFloat) -> UIFont!
}

extension FontConvertible where Self: RawRepresentable, Self.RawValue == String {
  func font(size: CGFloat) -> UIFont! {
    return UIFont(font: self, size: size)
  }
}

extension UIFont {
  convenience init!<FontType: FontConvertible where FontType: RawRepresentable, FontType.RawValue == String>(font: FontType, size: CGFloat) {
    self.init(name: font.rawValue, size: size)
  }
}

struct FontFamily {
  enum AppleSymbols: String {
      case Regular = "AppleSymbols"
  }
}
```

Nether of the two example [usages on the README](https://github.com/AliSoftware/SwiftGen#usage-1) compiles successfully:

```swift
// Value of type 'FontFamily.AppleSymbols' has no member 'font'
let font = FontFamily.AppleSymbols.Regular.font(38)

// Cannot invoke initializer for type 'UIFont' with an argument list of type '(font: FontFamily.AppleSymbols, size: CGFloat)'
UIFont(font: FontFamily.AppleSymbols.Regular, size: 38)
```

However, this tiny change to the template resolves the issue with both of them.