### PR TITLE
Update UIFont example on readme to match default template

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ struct FontFamily {
 // Helvetica Bold font of point size 16.0
 let font = FontFamily.Helvetica.Bold.font(16.0)
 // Another way to build the same font
-let sameFont = UIFont(family: FontFamily.Helvetica.Bold, size: 16.0)
+let sameFont = UIFont(font: FontFamily.Helvetica.Bold, size: 16.0)
 ```
 
 ---


### PR DESCRIPTION
I really like the `init(family:size:)` convenience constructor in the [usage example](https://github.com/AliSoftware/SwiftGen#usage-1). This changes the default template to match.