### PR TITLE
Add tvOS and watchOS support for Images, Fonts, Colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@
 
 * Fix issue with txt files bailing on comments  
 [Derek Ostrander](https://github.com/dostrander), [#140](https://github.com/AliSoftware/SwiftGen/issues/140)
-
+* Added support for tvOS and watchOS in images, fonts and color templates.  
+[Tom Baranes](https://github.com/tbaranes),
+  [#145](https://github.com/AliSoftware/SwiftGen/pull/145)
+  
 ## 1.1.2
 
 * Fix issue introduced by 1.1.1 in storyboard templates not returning.  

--- a/UnitTests/expected/Colors-Empty.swift.out
+++ b/UnitTests/expected/Colors-Empty.swift.out
@@ -1,6 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen
 
-#if os(iOS)
+#if os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIColor
   typealias Color = UIColor
 #elseif os(OSX)

--- a/UnitTests/expected/Colors-File-CustomName.swift.out
+++ b/UnitTests/expected/Colors-File-CustomName.swift.out
@@ -1,6 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen
 
-#if os(iOS)
+#if os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIColor
   typealias Color = UIColor
 #elseif os(OSX)

--- a/UnitTests/expected/Colors-File-Default.swift.out
+++ b/UnitTests/expected/Colors-File-Default.swift.out
@@ -1,6 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen
 
-#if os(iOS)
+#if os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIColor
   typealias Color = UIColor
 #elseif os(OSX)

--- a/UnitTests/expected/Colors-List-Default.swift.out
+++ b/UnitTests/expected/Colors-List-Default.swift.out
@@ -1,6 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen
 
-#if os(iOS)
+#if os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIColor
   typealias Color = UIColor
 #elseif os(OSX)

--- a/UnitTests/expected/Colors-List-RawValue.swift.out
+++ b/UnitTests/expected/Colors-List-RawValue.swift.out
@@ -1,6 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen
 
-#if os(iOS)
+#if os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIColor
   typealias Color = UIColor
 #elseif os(OSX)

--- a/UnitTests/expected/Colors-Txt-File-CustomName.swift.out
+++ b/UnitTests/expected/Colors-Txt-File-CustomName.swift.out
@@ -1,6 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen
 
-#if os(iOS)
+#if os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIColor
   typealias Color = UIColor
 #elseif os(OSX)

--- a/UnitTests/expected/Colors-Txt-File-Default.swift.out
+++ b/UnitTests/expected/Colors-Txt-File-Default.swift.out
@@ -1,6 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen
 
-#if os(iOS)
+#if os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIColor
   typealias Color = UIColor
 #elseif os(OSX)

--- a/UnitTests/expected/Fonts-Dir-CustomName.swift.out
+++ b/UnitTests/expected/Fonts-Dir-CustomName.swift.out
@@ -1,6 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen
 
-#if os(iOS)
+#if os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIFont
   typealias Font = UIFont
 #elseif os(OSX)

--- a/UnitTests/expected/Fonts-Dir-Default.swift.out
+++ b/UnitTests/expected/Fonts-Dir-Default.swift.out
@@ -1,6 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen
 
-#if os(iOS)
+#if os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIFont
   typealias Font = UIFont
 #elseif os(OSX)

--- a/UnitTests/expected/Images-Entries-Default.swift.out
+++ b/UnitTests/expected/Images-Entries-Default.swift.out
@@ -1,6 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen
 
-#if os(iOS)
+#if os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIImage
   typealias Image = UIImage
 #elseif os(OSX)

--- a/UnitTests/expected/Images-File-AllValues.swift.out
+++ b/UnitTests/expected/Images-File-AllValues.swift.out
@@ -1,6 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen
 
-#if os(iOS)
+#if os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIImage
   typealias Image = UIImage
 #elseif os(OSX)

--- a/UnitTests/expected/Images-File-CustomName.swift.out
+++ b/UnitTests/expected/Images-File-CustomName.swift.out
@@ -1,6 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen
 
-#if os(iOS)
+#if os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIImage
   typealias Image = UIImage
 #elseif os(OSX)

--- a/UnitTests/expected/Images-File-Default.swift.out
+++ b/UnitTests/expected/Images-File-Default.swift.out
@@ -1,6 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen
 
-#if os(iOS)
+#if os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIImage
   typealias Image = UIImage
 #elseif os(OSX)

--- a/templates/colors-default.stencil
+++ b/templates/colors-default.stencil
@@ -1,6 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen
 
-#if os(iOS)
+#if os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIColor
   typealias Color = UIColor
 #elseif os(OSX)

--- a/templates/colors-rawValue.stencil
+++ b/templates/colors-rawValue.stencil
@@ -1,6 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen
 
-#if os(iOS)
+#if os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIColor
   typealias Color = UIColor
 #elseif os(OSX)

--- a/templates/fonts-default.stencil
+++ b/templates/fonts-default.stencil
@@ -1,7 +1,7 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen
 
 {% if families %}
-#if os(iOS)
+#if os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIFont
   typealias Font = UIFont
 #elseif os(OSX)

--- a/templates/images-allvalues.stencil
+++ b/templates/images-allvalues.stencil
@@ -1,7 +1,7 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen
 
 {% if images %}
-#if os(iOS)
+#if os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIImage
   typealias Image = UIImage
 #elseif os(OSX)

--- a/templates/images-default.stencil
+++ b/templates/images-default.stencil
@@ -1,7 +1,7 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen
 
 {% if images %}
-#if os(iOS)
+#if os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIImage
   typealias Image = UIImage
 #elseif os(OSX)


### PR DESCRIPTION
Fix #143 
**Note:** as said in the other thread, I didn't test the output in a real project. Based on @Megatron1000 comments, it should work since it was working before.

OS X support didn't change localizables and storyboards templates, so if it was working before, it should still work as expected.