### PR TITLE
Fix swift 3 renaming compile error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   * `swiftgen templates cat <name>` prints the content to the template named `<name>`
   * `<name>` here can be either a subcommand name like `colors` or a
     composed name `colors-rawValue` for a specific template.
+* Fix swift 3 renaming change in strings-swift3.stencil
+  [Kilian Koeltzsch](https://github.com/kiliankoe), [#150](https://github.com/AliSoftware/SwiftGen/pull/150)
 
 > 💡 You can now **create your custom templates more easier than ever**, by cloning an existing template!
 >

--- a/UnitTests/expected/Strings-Localizable-Swift3.swift.out
+++ b/UnitTests/expected/Strings-Localizable-Swift3.swift.out
@@ -54,7 +54,7 @@ extension L10n: CustomStringConvertible {
 
   private static func tr(key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, comment: "")
-    return String(format: format, locale: NSLocale.current(), arguments: args)
+    return String(format: format, locale: Locale.current, arguments: args)
   }
 }
 

--- a/templates/strings-swift3.stencil
+++ b/templates/strings-swift3.stencil
@@ -32,7 +32,7 @@ extension {{enumName}}: CustomStringConvertible {
 
   private static func tr(key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, comment: "")
-    return String(format: format, locale: NSLocale.current(), arguments: args)
+    return String(format: format, locale: Locale.current, arguments: args)
   }
 }
 


### PR DESCRIPTION
`NSLocale.current()` has been renamed to `Locale.current`