### PR TITLE
Improvements for Swift 3 in Xcode 8 beta 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   [Syo Ikeda](https://github.com/ikesyo), [#153](https://github.com/AliSoftware/SwiftGen/pull/153)
 * Add support for font files containing multiple descriptors.  
   [Chris Ellsworth](https://github.com/chrisellsworth), [#156](https://github.com/AliSoftware/SwiftGen/pull/156)
+* Update deprecated usage of generics for Swift 3 / Xcode 8 beta 6.  
+  [Chris Ellsworth](https://github.com/chrisellsworth), [#158](https://github.com/AliSoftware/SwiftGen/pull/158)
 
 > 💡 You can now **create your custom templates more easier than ever**, by cloning an existing template!
 >

--- a/SwiftGen.xcodeproj/project.pbxproj
+++ b/SwiftGen.xcodeproj/project.pbxproj
@@ -85,6 +85,9 @@
 		C25A54341CEE7CEB00401BE5 /* Colors-Txt-File-CustomName.swift.out in Resources */ = {isa = PBXBuildFile; fileRef = C25A54331CEE7CEB00401BE5 /* Colors-Txt-File-CustomName.swift.out */; };
 		C2DBEADE1C8F87AD00E62C9E /* FontsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2DBEADD1C8F87AD00E62C9E /* FontsTests.swift */; };
 		D7C858DF1D5D4A4E00EA2C07 /* Avenir.ttc in Resources */ = {isa = PBXBuildFile; fileRef = D7C858DE1D5D4A4E00EA2C07 /* Avenir.ttc */; };
+		D7A14A861D64FD40002F4C65 /* fonts-swift3.stencil in Resources */ = {isa = PBXBuildFile; fileRef = D7A14A851D64FD2F002F4C65 /* fonts-swift3.stencil */; };
+		D7A14A8B1D64FE35002F4C65 /* Fonts-Dir-CustomName-Swift3.swift.out in Resources */ = {isa = PBXBuildFile; fileRef = D7A14A891D64FE35002F4C65 /* Fonts-Dir-CustomName-Swift3.swift.out */; };
+		D7A14A8C1D64FE35002F4C65 /* Fonts-Dir-Default-Swift3.swift.out in Resources */ = {isa = PBXBuildFile; fileRef = D7A14A8A1D64FE35002F4C65 /* Fonts-Dir-Default-Swift3.swift.out */; };
 		E2679A4B1D044D4600D3F55B /* Storyboards-osx-All-Default.swift.out in Resources */ = {isa = PBXBuildFile; fileRef = E2679A4A1D044D4600D3F55B /* Storyboards-osx-All-Default.swift.out */; };
 		E29942C11D1C640A002A29C4 /* storyboards-osx-lowercase.stencil in Resources */ = {isa = PBXBuildFile; fileRef = E29942C01D1C640A002A29C4 /* storyboards-osx-lowercase.stencil */; };
 		E29942C31D1C6560002A29C4 /* Storyboards-osx-Message-Lowercase.swift.out in Resources */ = {isa = PBXBuildFile; fileRef = E29942C21D1C6560002A29C4 /* Storyboards-osx-Message-Lowercase.swift.out */; };
@@ -229,6 +232,9 @@
 		C25A54331CEE7CEB00401BE5 /* Colors-Txt-File-CustomName.swift.out */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Colors-Txt-File-CustomName.swift.out"; sourceTree = "<group>"; };
 		C2DBEADD1C8F87AD00E62C9E /* FontsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FontsTests.swift; sourceTree = "<group>"; };
 		D7C858DE1D5D4A4E00EA2C07 /* Avenir.ttc */ = {isa = PBXFileReference; lastKnownFileType = file; path = Avenir.ttc; sourceTree = "<group>"; };
+		D7A14A851D64FD2F002F4C65 /* fonts-swift3.stencil */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "fonts-swift3.stencil"; sourceTree = "<group>"; };
+		D7A14A891D64FE35002F4C65 /* Fonts-Dir-CustomName-Swift3.swift.out */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = "Fonts-Dir-CustomName-Swift3.swift.out"; path = "UnitTests/expected/Fonts-Dir-CustomName-Swift3.swift.out"; sourceTree = SOURCE_ROOT; };
+		D7A14A8A1D64FE35002F4C65 /* Fonts-Dir-Default-Swift3.swift.out */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = "Fonts-Dir-Default-Swift3.swift.out"; path = "UnitTests/expected/Fonts-Dir-Default-Swift3.swift.out"; sourceTree = SOURCE_ROOT; };
 		E0542E32A906407325456A56 /* Pods-swiftgen.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-swiftgen.release.xcconfig"; path = "Pods/Target Support Files/Pods-swiftgen/Pods-swiftgen.release.xcconfig"; sourceTree = "<group>"; };
 		E2679A4A1D044D4600D3F55B /* Storyboards-osx-All-Default.swift.out */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Storyboards-osx-All-Default.swift.out"; sourceTree = "<group>"; };
 		E29942C01D1C640A002A29C4 /* storyboards-osx-lowercase.stencil */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "storyboards-osx-lowercase.stencil"; sourceTree = "<group>"; };
@@ -356,6 +362,7 @@
 				47CB533B1CFC16FE00AA19C0 /* strings-swift3.stencil */,
 				820D84AF1D1F9D6C00504948 /* strings-structured.stencil */,
 				C24AFD031C91E63D005FE3EF /* fonts-default.stencil */,
+				D7A14A851D64FD2F002F4C65 /* fonts-swift3.stencil */,
 			);
 			path = templates;
 			sourceTree = "<group>";
@@ -478,7 +485,9 @@
 			children = (
 				C24AFD091C924188005FE3EF /* Fonts-Dir-Empty.swift.out */,
 				C24AFD0B1C924760005FE3EF /* Fonts-Dir-Default.swift.out */,
+				D7A14A8A1D64FE35002F4C65 /* Fonts-Dir-Default-Swift3.swift.out */,
 				C24AFD0D1C924A29005FE3EF /* Fonts-Dir-CustomName.swift.out */,
+				D7A14A891D64FE35002F4C65 /* Fonts-Dir-CustomName-Swift3.swift.out */,
 			);
 			path = Fonts;
 			sourceTree = "<group>";
@@ -607,6 +616,7 @@
 				4761E0361BDE753000B9B05F /* Colors-Empty.swift.out in Resources */,
 				09A87B641BCCA4DC00D9B9F5 /* Images.xcassets in Resources */,
 				E2679A4B1D044D4600D3F55B /* Storyboards-osx-All-Default.swift.out in Resources */,
+				D7A14A861D64FD40002F4C65 /* fonts-swift3.stencil in Resources */,
 				C24AFD041C92370D005FE3EF /* fonts-default.stencil in Resources */,
 				4761E0381BDE753000B9B05F /* Storyboards-Empty.swift.out in Resources */,
 				641CD33E1C3AE35A00D7FED9 /* colors.clr in Resources */,
@@ -616,8 +626,10 @@
 				E29942C31D1C6560002A29C4 /* Storyboards-osx-Message-Lowercase.swift.out in Resources */,
 				0911503B1BD3ECAE00EBC803 /* colors-default.stencil in Resources */,
 				820D84AE1D1F9CAF00504948 /* Strings-File-Structured.swift.out in Resources */,
+				D7A14A8B1D64FE35002F4C65 /* Fonts-Dir-CustomName-Swift3.swift.out in Resources */,
 				09A87B6D1BCCA5F600D9B9F5 /* Strings-File-Default.swift.out in Resources */,
 				09EB0A2A1BDC60F000B2CF79 /* Images-Entries-Default.swift.out in Resources */,
+				D7A14A8C1D64FE35002F4C65 /* Fonts-Dir-Default-Swift3.swift.out in Resources */,
 				09A87B6E1BCCA5F600D9B9F5 /* Strings-File-CustomName.swift.out in Resources */,
 				099662301D1C8D7300366642 /* Storyboards-iOS in Resources */,
 				4761E0371BDE753000B9B05F /* Images-Empty.swift.out in Resources */,

--- a/UnitTests/TestSuites/FontsTests.swift
+++ b/UnitTests/TestSuites/FontsTests.swift
@@ -29,6 +29,16 @@ class FontsTests: XCTestCase {
     XCTDiffStrings(result, expected)
   }
 
+  func testDefaultsWithSwift3() {
+    let parser = FontsFileParser()
+    parser.parseFonts(directoryPath())
+
+    let template = GenumTemplate(templateString: fixtureString("fonts-swift3.stencil"))
+    let result = try! template.render(parser.stencilContext())
+    let expected = fixtureString("Fonts-Dir-Default-Swift3.swift.out")
+    XCTDiffStrings(result, expected)
+  }
+
   func testCustomName() {
     let parser = FontsFileParser()
     parser.parseFonts(directoryPath())
@@ -36,6 +46,16 @@ class FontsTests: XCTestCase {
     let template = GenumTemplate(templateString: fixtureString("fonts-default.stencil"))
     let result = try! template.render(parser.stencilContext(enumName: "CustomFamily"))
     let expected = fixtureString("Fonts-Dir-CustomName.swift.out")
+    XCTDiffStrings(result, expected)
+  }
+
+  func testCustomNameWithSwift3() {
+    let parser = FontsFileParser()
+    parser.parseFonts(directoryPath())
+
+    let template = GenumTemplate(templateString: fixtureString("fonts-swift3.stencil"))
+    let result = try! template.render(parser.stencilContext(enumName: "CustomFamily"))
+    let expected = fixtureString("Fonts-Dir-CustomName-Swift3.swift.out")
     XCTDiffStrings(result, expected)
   }
 }

--- a/UnitTests/expected/Fonts-Dir-CustomName-Swift3.swift.out
+++ b/UnitTests/expected/Fonts-Dir-CustomName-Swift3.swift.out
@@ -1,0 +1,60 @@
+// Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen
+
+#if os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIFont
+  typealias Font = UIFont
+#elseif os(OSX)
+  import AppKit.NSFont
+  typealias Font = NSFont
+#endif
+
+// swiftlint:disable file_length
+
+protocol FontConvertible {
+  func font(size: CGFloat) -> Font!
+}
+
+extension FontConvertible where Self: RawRepresentable, Self.RawValue == String {
+  func font(size: CGFloat) -> Font! {
+    return Font(font: self, size: size)
+  }
+}
+
+extension Font {
+  convenience init!<FontType: FontConvertible>
+    (font: FontType, size: CGFloat)
+    where FontType: RawRepresentable, FontType.RawValue == String {
+      self.init(name: font.rawValue, size: size)
+  }
+}
+
+struct CustomFamily {
+  enum Avenir: String, FontConvertible {
+    case Black = "Avenir-Black"
+    case BlackOblique = "Avenir-BlackOblique"
+    case Light = "Avenir-Light"
+    case MediumOblique = "Avenir-MediumOblique"
+    case Roman = "Avenir-Roman"
+    case Heavy = "Avenir-Heavy"
+    case HeavyOblique = "Avenir-HeavyOblique"
+    case Medium = "Avenir-Medium"
+    case Oblique = "Avenir-Oblique"
+    case LightOblique = "Avenir-LightOblique"
+    case Book = "Avenir-Book"
+    case BookOblique = "Avenir-BookOblique"
+  }
+  enum SFNSDisplay: String, FontConvertible {
+    case Regular = ".SFNSDisplay-Regular"
+    case Heavy = ".SFNSDisplay-Heavy"
+    case Black = ".SFNSDisplay-Black"
+    case Bold = ".SFNSDisplay-Bold"
+  }
+  enum SFNSText: String, FontConvertible {
+    case Heavy = ".SFNSText-Heavy"
+    case Bold = ".SFNSText-Bold"
+    case Regular = ".SFNSText-Regular"
+  }
+  enum ZapfDingbats: String, FontConvertible {
+    case Regular = "ZapfDingbatsITC"
+  }
+}

--- a/UnitTests/expected/Fonts-Dir-Default-Swift3.swift.out
+++ b/UnitTests/expected/Fonts-Dir-Default-Swift3.swift.out
@@ -1,0 +1,60 @@
+// Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen
+
+#if os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIFont
+  typealias Font = UIFont
+#elseif os(OSX)
+  import AppKit.NSFont
+  typealias Font = NSFont
+#endif
+
+// swiftlint:disable file_length
+
+protocol FontConvertible {
+  func font(size: CGFloat) -> Font!
+}
+
+extension FontConvertible where Self: RawRepresentable, Self.RawValue == String {
+  func font(size: CGFloat) -> Font! {
+    return Font(font: self, size: size)
+  }
+}
+
+extension Font {
+  convenience init!<FontType: FontConvertible>
+    (font: FontType, size: CGFloat)
+    where FontType: RawRepresentable, FontType.RawValue == String {
+      self.init(name: font.rawValue, size: size)
+  }
+}
+
+struct FontFamily {
+  enum Avenir: String, FontConvertible {
+    case Black = "Avenir-Black"
+    case BlackOblique = "Avenir-BlackOblique"
+    case Light = "Avenir-Light"
+    case MediumOblique = "Avenir-MediumOblique"
+    case Roman = "Avenir-Roman"
+    case Heavy = "Avenir-Heavy"
+    case HeavyOblique = "Avenir-HeavyOblique"
+    case Medium = "Avenir-Medium"
+    case Oblique = "Avenir-Oblique"
+    case LightOblique = "Avenir-LightOblique"
+    case Book = "Avenir-Book"
+    case BookOblique = "Avenir-BookOblique"
+  }
+  enum SFNSDisplay: String, FontConvertible {
+    case Regular = ".SFNSDisplay-Regular"
+    case Heavy = ".SFNSDisplay-Heavy"
+    case Black = ".SFNSDisplay-Black"
+    case Bold = ".SFNSDisplay-Bold"
+  }
+  enum SFNSText: String, FontConvertible {
+    case Heavy = ".SFNSText-Heavy"
+    case Bold = ".SFNSText-Bold"
+    case Regular = ".SFNSText-Regular"
+  }
+  enum ZapfDingbats: String, FontConvertible {
+    case Regular = "ZapfDingbatsITC"
+  }
+}

--- a/UnitTests/expected/Storyboards-Anonymous-Swift3.swift.out
+++ b/UnitTests/expected/Storyboards-Anonymous-Swift3.swift.out
@@ -32,7 +32,7 @@ extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == Str
 protocol StoryboardSegueType: RawRepresentable { }
 
 extension UIViewController {
-  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+  func performSegue<S: StoryboardSegueType>(segue: S, sender: AnyObject? = nil) where S.RawValue == String {
     performSegue(withIdentifier: segue.rawValue, sender: sender)
   }
 }

--- a/UnitTests/expected/Storyboards-Wizard-Swift3.swift.out
+++ b/UnitTests/expected/Storyboards-Wizard-Swift3.swift.out
@@ -32,7 +32,7 @@ extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == Str
 protocol StoryboardSegueType: RawRepresentable { }
 
 extension UIViewController {
-  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+  func performSegue<S: StoryboardSegueType>(segue: S, sender: AnyObject? = nil) where S.RawValue == String {
     performSegue(withIdentifier: segue.rawValue, sender: sender)
   }
 }

--- a/templates/fonts-swift3.stencil
+++ b/templates/fonts-swift3.stencil
@@ -1,0 +1,43 @@
+// Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen
+
+{% if families %}
+#if os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIFont
+  typealias Font = UIFont
+#elseif os(OSX)
+  import AppKit.NSFont
+  typealias Font = NSFont
+#endif
+
+// swiftlint:disable file_length
+
+protocol FontConvertible {
+  func font(size: CGFloat) -> Font!
+}
+
+extension FontConvertible where Self: RawRepresentable, Self.RawValue == String {
+  func font(size: CGFloat) -> Font! {
+    return Font(font: self, size: size)
+  }
+}
+
+extension Font {
+  convenience init!<FontType: FontConvertible>
+    (font: FontType, size: CGFloat)
+    where FontType: RawRepresentable, FontType.RawValue == String {
+      self.init(name: font.rawValue, size: size)
+  }
+}
+
+struct {{enumName}} {
+  {% for family in families %}
+  enum {{family.name|swiftIdentifier|snakeToCamelCaseNoPrefix}}: String, FontConvertible {
+    {% for font in family.fonts %}
+    case {{font.style|swiftIdentifier|snakeToCamelCaseNoPrefix}} = "{{font.fontName}}"
+    {% endfor %}
+  }
+  {% endfor %}
+}
+{% else %}
+// No fonts found
+{% endif %}

--- a/templates/storyboards-swift3.stencil
+++ b/templates/storyboards-swift3.stencil
@@ -33,7 +33,7 @@ extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == Str
 protocol StoryboardSegueType: RawRepresentable { }
 
 extension UIViewController {
-  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
+  func performSegue<S: StoryboardSegueType>(segue: S, sender: AnyObject? = nil) where S.RawValue == String {
     performSegue(withIdentifier: segue.rawValue, sender: sender)
   }
 }


### PR DESCRIPTION
As of Xcode 8 beta 6, we now get the following build warning for storyboards and fonts:

> 'where' clause next to generic parameters is deprecated and will be removed in the future version of Swift

Added a `swift3` template for fonts and made a change to the `swift3` template for storyboards in order to prevent this warning.