### PR TITLE
Storyboard Segue Templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ---
 
+## unreleased
+
+* Change swift 3 storyboard segue template's sender from `AnyObject` to `Any`. 
+  [Derek Ostrander](https://github.com/dostrander)
+* Fix swift 3 storyboard templates to be compliant with swift 3 api design guidelines.
+  [Afonso](https://github.com/afonsograca)
+
 ## 3.0.1
 
 * Add support for Xcode 8 and Swift 2.3.  

--- a/UnitTests/expected/Storyboards-AdditionalImport-Swift3.swift.out
+++ b/UnitTests/expected/Storyboards-AdditionalImport-Swift3.swift.out
@@ -38,7 +38,7 @@ extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == Str
 protocol StoryboardSegueType: RawRepresentable { }
 
 extension UIViewController {
-  func perform<S: StoryboardSegueType>(segue: S, sender: AnyObject? = nil) where S.RawValue == String {
+  func perform<S: StoryboardSegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
     performSegue(withIdentifier: segue.rawValue, sender: sender)
   }
 }

--- a/UnitTests/expected/Storyboards-Anonymous-Swift3.swift.out
+++ b/UnitTests/expected/Storyboards-Anonymous-Swift3.swift.out
@@ -36,7 +36,7 @@ extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == Str
 protocol StoryboardSegueType: RawRepresentable { }
 
 extension UIViewController {
-  func perform<S: StoryboardSegueType>(segue: S, sender: AnyObject? = nil) where S.RawValue == String {
+  func perform<S: StoryboardSegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
     performSegue(withIdentifier: segue.rawValue, sender: sender)
   }
 }

--- a/UnitTests/expected/Storyboards-Wizard-Swift3.swift.out
+++ b/UnitTests/expected/Storyboards-Wizard-Swift3.swift.out
@@ -36,7 +36,7 @@ extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == Str
 protocol StoryboardSegueType: RawRepresentable { }
 
 extension UIViewController {
-  func perform<S: StoryboardSegueType>(segue: S, sender: AnyObject? = nil) where S.RawValue == String {
+  func perform<S: StoryboardSegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
     performSegue(withIdentifier: segue.rawValue, sender: sender)
   }
 }

--- a/templates/storyboards-swift3.stencil
+++ b/templates/storyboards-swift3.stencil
@@ -37,7 +37,7 @@ extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == Str
 protocol StoryboardSegueType: RawRepresentable { }
 
 extension UIViewController {
-  func perform<S: StoryboardSegueType>(segue: S, sender: AnyObject? = nil) where S.RawValue == String {
+  func perform<S: StoryboardSegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
     performSegue(withIdentifier: segue.rawValue, sender: sender)
   }
 }


### PR DESCRIPTION
- Change swift 3 storyboard segue template's sender from `AnyObject` to `Any`
- Added afonsograca to changelog