### PR TITLE
Add changelog entry for escaping reserved keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
   this flag.  
   [David Jennes](https://github.com/djbe), [#175](https://github.com/AliSoftware/SwiftGen/pull/175) 
 * Remove the `key` param label from the `tr` function for Localized String in the swift3 template [AndrewSB](https://github.com/AndrewSB), [#190](https://github.com/AliSoftware/SwiftGen/pull/190)
+* Escape reserved swift keywords in the structured and dot-syntax generated strings code.  
+  [Afonso](https://github.com/afonsograca)
+  [#198](https://github.com/AliSoftware/SwiftGen/pull/198)
 
 ## 3.0.1
 


### PR DESCRIPTION
Apparently we can't directly modify the changelog