### PR TITLE
Escape String constant names

### DIFF
--- a/templates/strings-dot-syntax-swift3.stencil
+++ b/templates/strings-dot-syntax-swift3.stencil
@@ -20,7 +20,7 @@ struct {{enumName}} {
     return {{enumName}}.tr("{{string.key}}", {{string.params.names|join}})
   }
   {% else %}
-  static let {{string.keytail|swiftIdentifier|titlecase|snakeToCamelCase|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{string.key}}")
+  static let `{{string.keytail|swiftIdentifier|titlecase|snakeToCamelCase|lowerFirstWord|escapeReservedKeywords}}` = {{enumName}}.tr("{{string.key}}")
   {% endif %}
   {% endfor %}
   {% if structuredStrings.subenums %}
@@ -36,7 +36,7 @@ struct {{enumName}} {
       return {{enumName}}.tr("{{string.key}}", {{string.params.names|join}})
     }
     {% else %}
-    static let {{string.keytail|swiftIdentifier|titlecase|snakeToCamelCase|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{string.key}}")
+    static let `{{string.keytail|swiftIdentifier|titlecase|snakeToCamelCase|lowerFirstWord|escapeReservedKeywords}}` = {{enumName}}.tr("{{string.key}}")
     {% endif %}
     {% endfor %}
     {% endif %}
@@ -53,7 +53,7 @@ struct {{enumName}} {
         return {{enumName}}.tr("{{string.key}}", {{string.params.names|join}})
       }
       {% else %}
-      static let {{string.keytail|swiftIdentifier|titlecase|snakeToCamelCase|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{string.key}}")
+      static let `{{string.keytail|swiftIdentifier|titlecase|snakeToCamelCase|lowerFirstWord|escapeReservedKeywords}}` = {{enumName}}.tr("{{string.key}}")
       {% endif %}
       {% endfor %}
       {% endif %}
@@ -70,7 +70,7 @@ struct {{enumName}} {
           return {{enumName}}.tr("{{string.key}}", {{string.params.names|join}})
         }
         {% else %}
-        static let {{string.keytail|swiftIdentifier|titlecase|snakeToCamelCase|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{string.key}}")
+        static let `{{string.keytail|swiftIdentifier|titlecase|snakeToCamelCase|lowerFirstWord|escapeReservedKeywords}}` = {{enumName}}.tr("{{string.key}}")
         {% endif %}
         {% endfor %}
         {% endif %}
@@ -87,7 +87,7 @@ struct {{enumName}} {
             return {{enumName}}.tr("{{string.key}}", {{string.params.names|join}})
           }
           {% else %}
-          static let {{string.keytail|swiftIdentifier|titlecase|snakeToCamelCase|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{string.key}}")
+          static let `{{string.keytail|swiftIdentifier|titlecase|snakeToCamelCase|lowerFirstWord|escapeReservedKeywords}}` = {{enumName}}.tr("{{string.key}}")
           {% endif %}
           {% endfor %}
           {% endif %}
@@ -104,7 +104,7 @@ struct {{enumName}} {
               return {{enumName}}.tr("{{string.key}}", {{string.params.names|join}})
             }
             {% else %}
-            static let {{string.keytail|swiftIdentifier|titlecase|snakeToCamelCase|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{string.key}}")
+            static let `{{string.keytail|swiftIdentifier|titlecase|snakeToCamelCase|lowerFirstWord|escapeReservedKeywords}}` = {{enumName}}.tr("{{string.key}}")
             {% endif %}
             {% endfor %}
             {% endif %}
@@ -121,7 +121,7 @@ struct {{enumName}} {
                 return {{enumName}}.tr("{{string.key}}", {{string.params.names|join}})
               }
               {% else %}
-              static let {{string.keytail|swiftIdentifier|titlecase|snakeToCamelCase|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{string.key}}")
+              static let `{{string.keytail|swiftIdentifier|titlecase|snakeToCamelCase|lowerFirstWord|escapeReservedKeywords}}` = {{enumName}}.tr("{{string.key}}")
               {% endif %}
               {% endfor %}
               {% endif %}


### PR DESCRIPTION
Currently, using reserved keywords like "any" as localization keys will result in a compiler error. This will avoid it.