### PR TITLE
Consolidate use of PathKit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Swift 3 migration.  
   [ahtierney](https://github.com/ahtierney)
   [#201](https://github.com/AliSoftware/SwiftGen/pull/201)
+* Consolidate use of PathKit internally.    
+  [David Jennes](https://github.com/djbe)
+  [#212](https://github.com/AliSoftware/SwiftGen/pull/212)
 
 ## 4.0.0
 

--- a/GenumKit/Parsers/AssetsCatalogParser.swift
+++ b/GenumKit/Parsers/AssetsCatalogParser.swift
@@ -22,7 +22,7 @@ public final class AssetsCatalogParser {
     }
   }
 
-  public func parseCatalog(at path: String) {
+  public func parseCatalog(at path: Path) {
     guard let items = loadAssetCatalog(at: path) else { return }
     // process recursively
     processCatalog(items: items)
@@ -46,7 +46,7 @@ extension AssetsCatalogParser {
       guard let filename = item[AssetCatalog.filename.rawValue] as? String else { continue }
       let path = Path(filename)
 
-      if path.`extension` == AssetsCatalogParser.imageSetExtension {
+      if path.extension == AssetsCatalogParser.imageSetExtension {
         // this is a simple imageset
         let imageName = path.lastComponentWithoutExtension
         addImage(named: "\(prefix)\(imageName)")
@@ -68,8 +68,8 @@ extension AssetsCatalogParser {
 // MARK: - ACTool
 
 extension AssetsCatalogParser {
-  fileprivate func loadAssetCatalog(at path: String) -> [[String: AnyObject]]? {
-    let command = Command("xcrun", arguments: "actool", "--print-contents", path)
+  fileprivate func loadAssetCatalog(at path: Path) -> [[String: AnyObject]]? {
+    let command = Command("xcrun", arguments: "actool", "--print-contents", String(describing: path))
     let output = command.execute() as Data
 
     // try to parse plist

--- a/GenumKit/Parsers/FontsFileParser.swift
+++ b/GenumKit/Parsers/FontsFileParser.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import AppKit.NSFont
+import PathKit
 
 // MARK: Font
 
@@ -57,8 +58,10 @@ public final class FontsFileParser {
 
   public init() {}
 
-  public func parseFile(at path: String) {
-    let url = URL(fileURLWithPath: path)
+  public func parseFile(at path: Path) {
+    // PathKit does not support support enumeration with options yet
+    let url = URL(fileURLWithPath: String(describing: path))
+
     if let dirEnum = FileManager.default.enumerator(at: url,
       includingPropertiesForKeys: [],
       options: [.skipsHiddenFiles, .skipsPackageDescendants],

--- a/GenumKit/Parsers/FontsFileParser.swift
+++ b/GenumKit/Parsers/FontsFileParser.swift
@@ -60,6 +60,7 @@ public final class FontsFileParser {
 
   public func parseFile(at path: Path) {
     // PathKit does not support support enumeration with options yet
+    // see: https://github.com/kylef/PathKit/pull/25
     let url = URL(fileURLWithPath: String(describing: path))
 
     if let dirEnum = FileManager.default.enumerator(at: url,

--- a/GenumKit/Parsers/StoryboardParser.swift
+++ b/GenumKit/Parsers/StoryboardParser.swift
@@ -5,6 +5,7 @@
 //
 
 import Foundation
+import PathKit
 
 public final class StoryboardParser {
   struct InitialScene {
@@ -86,25 +87,25 @@ public final class StoryboardParser {
     }
   }
 
-  public func addStoryboard(at path: String) {
-    let parser = XMLParser(contentsOf: URL(fileURLWithPath: path))
+  public func addStoryboard(at path: Path) throws {
+    let parser = XMLParser(data: try path.read())
 
     let delegate = ParserDelegate()
-    parser?.delegate = delegate
-    parser?.parse()
+    parser.delegate = delegate
+    parser.parse()
 
-    let storyboardName = ((path as NSString).lastPathComponent as NSString).deletingPathExtension
+    let storyboardName = path.lastComponentWithoutExtension
     initialScenes[storyboardName] = delegate.initialScene
     storyboardsScenes[storyboardName] = delegate.scenes
     storyboardsSegues[storyboardName] = delegate.segues
   }
 
-  public func parseDirectory(at path: String) {
-    if let dirEnum = FileManager.default.enumerator(atPath: path) {
-      while let subPath = dirEnum.nextObject() as? NSString {
-        if subPath.pathExtension == "storyboard" {
-          self.addStoryboard(at: (path as NSString).appendingPathComponent(subPath as String))
-        }
+  public func parseDirectory(at path: Path) throws {
+    let iterator = path.makeIterator()
+
+    while let subPath = iterator.next() {
+      if subPath.extension == "storyboard" {
+        try addStoryboard(at: subPath)
       }
     }
   }

--- a/GenumKit/Parsers/StringsFileParser.swift
+++ b/GenumKit/Parsers/StringsFileParser.swift
@@ -5,6 +5,7 @@
 //
 
 import Foundation
+import PathKit
 
 public enum StringsFileParserError: Error, CustomStringConvertible {
   case FailureOnLoading(path: String)
@@ -30,9 +31,9 @@ public final class StringsFileParser {
   }
 
   // Localizable.strings files are generally UTF16, not UTF8!
-  public func parseFile(at path: String) throws {
-    guard let data = try? NSData(contentsOfFile: path) as Data else {
-      throw StringsFileParserError.FailureOnLoading(path: path)
+  public func parseFile(at path: Path) throws {
+    guard let data = try? path.read() else {
+      throw StringsFileParserError.FailureOnLoading(path: String(describing: path))
     }
 
     let plist = try PropertyListSerialization

--- a/UnitTests/TestSuites/ColorsTests.swift
+++ b/UnitTests/TestSuites/ColorsTests.swift
@@ -18,7 +18,7 @@ class ColorsTextFileTests: XCTestCase {
     let template = GenumTemplate(templateString: fixtureString("colors-default.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Colors-Empty.swift.out")
+    let expected = fixtureString("Colors-Empty.swift.out")
     XCTDiffStrings(result, expected)
   }
 
@@ -35,7 +35,7 @@ class ColorsTextFileTests: XCTestCase {
     let template = GenumTemplate(templateString: fixtureString("colors-default.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Colors-List-Default.swift.out")
+    let expected = fixtureString("Colors-List-Default.swift.out")
     XCTDiffStrings(result, expected)
   }
 
@@ -52,47 +52,47 @@ class ColorsTextFileTests: XCTestCase {
     let template = GenumTemplate(templateString: fixtureString("colors-rawValue.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Colors-List-RawValue.swift.out")
+    let expected = fixtureString("Colors-List-RawValue.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testFileWithDefaults() {
     let parser = ColorsTextFileParser()
-    try! parser.parseFile(at: fixturePath("colors.txt"))
+    try! parser.parseFile(at: fixture("colors.txt"))
 
     let template = GenumTemplate(templateString: fixtureString("colors-default.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Colors-Txt-File-Default.swift.out")
+    let expected = fixtureString("Colors-Txt-File-Default.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testFileSwift3() {
     let parser = ColorsTextFileParser()
-    try! parser.parseFile(at: fixturePath("colors.txt"))
+    try! parser.parseFile(at: fixture("colors.txt"))
 
     let template = GenumTemplate(templateString: fixtureString("colors-swift3.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Colors-Txt-File-Swift3.swift.out")
+    let expected = fixtureString("Colors-Txt-File-Swift3.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testFileWithCustomName() {
     let parser = ColorsTextFileParser()
-    try! parser.parseFile(at: fixturePath("colors.txt"))
+    try! parser.parseFile(at: fixture("colors.txt"))
 
     let template = GenumTemplate(templateString: fixtureString("colors-default.stencil"))
     let result = try! template.render(parser.stencilContext(enumName: "XCTColors"))
 
-    let expected = self.fixtureString("Colors-Txt-File-CustomName.swift.out")
+    let expected = fixtureString("Colors-Txt-File-CustomName.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testFileWithBadFormatting() {
     let parser = ColorsTextFileParser()
     do {
-      try parser.parseFile(at: fixturePath("colors-bad.txt"))
+      try parser.parseFile(at: fixture("colors-bad.txt"))
       XCTFail("Code did parse file successfully while it was expected to fail for bad formatting")
     } catch ColorsParserError.invalidHexColor(string: ":", key: "MX_WELCOME_BACKGROUND"?) {
       // That's the expected exception we want to happen
@@ -113,29 +113,29 @@ class ColorsCLRFileTests: XCTestCase {
     let template = GenumTemplate(templateString: fixtureString("colors-default.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Colors-Empty.swift.out")
+    let expected = fixtureString("Colors-Empty.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testFileWithDefaults() {
     let parser = ColorsCLRFileParser()
-    parser.parseFile(at: fixturePath("colors.clr"))
+    parser.parseFile(at: fixture("colors.clr"))
 
     let template = GenumTemplate(templateString: fixtureString("colors-default.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Colors-File-Default.swift.out")
+    let expected = fixtureString("Colors-File-Default.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testFileWithCustomName() {
     let parser = ColorsCLRFileParser()
-    parser.parseFile(at: fixturePath("colors.clr"))
+    parser.parseFile(at: fixture("colors.clr"))
 
     let template = GenumTemplate(templateString: fixtureString("colors-default.stencil"))
     let result = try! template.render(parser.stencilContext(enumName: "XCTColors"))
 
-    let expected = self.fixtureString("Colors-File-CustomName.swift.out")
+    let expected = fixtureString("Colors-File-CustomName.swift.out")
     XCTDiffStrings(result, expected)
   }
 }
@@ -149,14 +149,14 @@ class ColorsXMLFileTests: XCTestCase {
     let template = GenumTemplate(templateString: fixtureString("colors-default.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Colors-Empty.swift.out")
+    let expected = fixtureString("Colors-Empty.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testFileWithDefaults() {
     let parser = ColorsXMLFileParser()
     do {
-      try parser.parseFile(at: fixturePath("colors.xml"))
+      try parser.parseFile(at: fixture("colors.xml"))
     } catch {
       XCTFail("Exception while parsing file: \(error)")
     }
@@ -164,14 +164,14 @@ class ColorsXMLFileTests: XCTestCase {
     let template = GenumTemplate(templateString: fixtureString("colors-default.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Colors-File-Default.swift.out")
+    let expected = fixtureString("Colors-File-Default.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testFileWithCustomName() {
     let parser = ColorsXMLFileParser()
     do {
-      try parser.parseFile(at: fixturePath("colors.xml"))
+      try parser.parseFile(at: fixture("colors.xml"))
     } catch {
       XCTFail("Exception while parsing file: \(error)")
     }
@@ -179,7 +179,7 @@ class ColorsXMLFileTests: XCTestCase {
     let template = GenumTemplate(templateString: fixtureString("colors-default.stencil"))
     let result = try! template.render(parser.stencilContext(enumName: "XCTColors"))
 
-    let expected = self.fixtureString("Colors-File-CustomName.swift.out")
+    let expected = fixtureString("Colors-File-CustomName.swift.out")
     XCTDiffStrings(result, expected)
   }
 }
@@ -191,14 +191,14 @@ class ColorsJSONFileTests: XCTestCase {
     let template = GenumTemplate(templateString: fixtureString("colors-default.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Colors-Empty.swift.out")
+    let expected = fixtureString("Colors-Empty.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testFileWithDefaults() {
     let parser = ColorsJSONFileParser()
     do {
-      try parser.parseFile(at: fixturePath("colors.json"))
+      try parser.parseFile(at: fixture("colors.json"))
     } catch {
       XCTFail("Exception while parsing file: \(error)")
     }
@@ -206,14 +206,14 @@ class ColorsJSONFileTests: XCTestCase {
     let template = GenumTemplate(templateString: fixtureString("colors-default.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Colors-File-Default.swift.out")
+    let expected = fixtureString("Colors-File-Default.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testFileWithCustomName() {
     let parser = ColorsJSONFileParser()
     do {
-      try parser.parseFile(at: fixturePath("colors.json"))
+      try parser.parseFile(at: fixture("colors.json"))
     } catch {
       XCTFail("Exception while parsing file: \(error)")
     }
@@ -221,7 +221,7 @@ class ColorsJSONFileTests: XCTestCase {
     let template = GenumTemplate(templateString: fixtureString("colors-default.stencil"))
     let result = try! template.render(parser.stencilContext(enumName: "XCTColors"))
 
-    let expected = self.fixtureString("Colors-File-CustomName.swift.out")
+    let expected = fixtureString("Colors-File-CustomName.swift.out")
     XCTDiffStrings(result, expected)
   }
 }

--- a/UnitTests/TestSuites/FontsTests.swift
+++ b/UnitTests/TestSuites/FontsTests.swift
@@ -21,7 +21,7 @@ class FontsTests: XCTestCase {
 
   func testDefaults() {
     let parser = FontsFileParser()
-    parser.parseFile(at: directoryPath())
+    parser.parseFile(at: directory())
 
     let template = GenumTemplate(templateString: fixtureString("fonts-default.stencil"))
     let result = try! template.render(parser.stencilContext())
@@ -31,7 +31,7 @@ class FontsTests: XCTestCase {
 
   func testDefaultsWithSwift3() {
     let parser = FontsFileParser()
-    parser.parseFile(at: directoryPath())
+    parser.parseFile(at: directory())
 
     let template = GenumTemplate(templateString: fixtureString("fonts-swift3.stencil"))
     let result = try! template.render(parser.stencilContext())
@@ -41,7 +41,7 @@ class FontsTests: XCTestCase {
 
   func testCustomName() {
     let parser = FontsFileParser()
-    parser.parseFile(at: directoryPath())
+    parser.parseFile(at: directory())
 
     let template = GenumTemplate(templateString: fixtureString("fonts-default.stencil"))
     let result = try! template.render(parser.stencilContext(enumName: "CustomFamily"))
@@ -51,7 +51,7 @@ class FontsTests: XCTestCase {
 
   func testCustomNameWithSwift3() {
     let parser = FontsFileParser()
-    parser.parseFile(at: directoryPath())
+    parser.parseFile(at: directory())
 
     let template = GenumTemplate(templateString: fixtureString("fonts-swift3.stencil"))
     let result = try! template.render(parser.stencilContext(enumName: "CustomFamily"))

--- a/UnitTests/TestSuites/ImagesTests.swift
+++ b/UnitTests/TestSuites/ImagesTests.swift
@@ -6,6 +6,7 @@
 
 import XCTest
 import GenumKit
+import PathKit
 
 /**
  * Important: In order for the "*.xcassets" files in fixtures/ to be copied as-is in the test bundle
@@ -40,7 +41,7 @@ class ImagesTests: XCTestCase {
 
   func testFileWithDefaults() {
     let parser = AssetsCatalogParser()
-    parser.parseCatalog(at: fixturePath("Images.xcassets"))
+    parser.parseCatalog(at: Path(fixturePath("Images.xcassets")))
 
     let template = GenumTemplate(templateString: fixtureString("images-default.stencil"))
     let result = try! template.render(parser.stencilContext())
@@ -51,7 +52,7 @@ class ImagesTests: XCTestCase {
 
   func testFileWithSwift3() {
     let parser = AssetsCatalogParser()
-    parser.parseCatalog(at: fixturePath("Images.xcassets"))
+    parser.parseCatalog(at: Path(fixturePath("Images.xcassets")))
 
     let template = GenumTemplate(templateString: fixtureString("images-swift3.stencil"))
     let result = try! template.render(parser.stencilContext())
@@ -62,7 +63,7 @@ class ImagesTests: XCTestCase {
 
   func testFileWithAllValuesTemplate() {
     let parser = AssetsCatalogParser()
-    parser.parseCatalog(at: fixturePath("Images.xcassets"))
+    parser.parseCatalog(at: Path(fixturePath("Images.xcassets")))
 
     let template = GenumTemplate(templateString: fixtureString("images-allvalues.stencil"))
     let result = try! template.render(parser.stencilContext())
@@ -73,7 +74,7 @@ class ImagesTests: XCTestCase {
 
   func testFileWithCustomName() {
     let parser = AssetsCatalogParser()
-    parser.parseCatalog(at: fixturePath("Images.xcassets"))
+    parser.parseCatalog(at: Path(fixturePath("Images.xcassets")))
 
     let template = GenumTemplate(templateString: fixtureString("images-default.stencil"))
     let result = try! template.render(parser.stencilContext(enumName: "XCTImages"))

--- a/UnitTests/TestSuites/ImagesTests.swift
+++ b/UnitTests/TestSuites/ImagesTests.swift
@@ -22,7 +22,7 @@ class ImagesTests: XCTestCase {
     let template = GenumTemplate(templateString: fixtureString("images-default.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Images-Empty.swift.out")
+    let expected = fixtureString("Images-Empty.swift.out")
     XCTDiffStrings(result, expected)
   }
 
@@ -35,51 +35,51 @@ class ImagesTests: XCTestCase {
     let template = GenumTemplate(templateString: fixtureString("images-default.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Images-Entries-Default.swift.out")
+    let expected = fixtureString("Images-Entries-Default.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testFileWithDefaults() {
     let parser = AssetsCatalogParser()
-    parser.parseCatalog(at: Path(fixturePath("Images.xcassets")))
+    parser.parseCatalog(at: fixture("Images.xcassets"))
 
     let template = GenumTemplate(templateString: fixtureString("images-default.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Images-File-Default.swift.out")
+    let expected = fixtureString("Images-File-Default.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testFileWithSwift3() {
     let parser = AssetsCatalogParser()
-    parser.parseCatalog(at: Path(fixturePath("Images.xcassets")))
+    parser.parseCatalog(at: fixture("Images.xcassets"))
 
     let template = GenumTemplate(templateString: fixtureString("images-swift3.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Images-File-Swift3.swift.out")
+    let expected = fixtureString("Images-File-Swift3.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testFileWithAllValuesTemplate() {
     let parser = AssetsCatalogParser()
-    parser.parseCatalog(at: Path(fixturePath("Images.xcassets")))
+    parser.parseCatalog(at: fixture("Images.xcassets"))
 
     let template = GenumTemplate(templateString: fixtureString("images-allvalues.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Images-File-AllValues.swift.out")
+    let expected = fixtureString("Images-File-AllValues.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testFileWithCustomName() {
     let parser = AssetsCatalogParser()
-    parser.parseCatalog(at: Path(fixturePath("Images.xcassets")))
+    parser.parseCatalog(at: fixture("Images.xcassets"))
 
     let template = GenumTemplate(templateString: fixtureString("images-default.stencil"))
     let result = try! template.render(parser.stencilContext(enumName: "XCTImages"))
 
-    let expected = self.fixtureString("Images-File-CustomName.swift.out")
+    let expected = fixtureString("Images-File-CustomName.swift.out")
     XCTDiffStrings(result, expected)
   }
 }

--- a/UnitTests/TestSuites/StoryboardsTests.swift
+++ b/UnitTests/TestSuites/StoryboardsTests.swift
@@ -28,92 +28,124 @@ class StoryboardsiOSTests: XCTestCase {
     let template = GenumTemplate(templateString: fixtureString("storyboards-default.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Storyboards-Empty.swift.out")
+    let expected = fixtureString("Storyboards-Empty.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testMessageStoryboardWithDefaults() {
     let parser = StoryboardParser()
-    parser.addStoryboard(at: self.fixturePath("Message.storyboard", subDirectory: StoryboardsDir.iOS))
+    do {
+      try parser.addStoryboard(at: fixture("Message.storyboard", subDirectory: StoryboardsDir.iOS))
+    } catch {
+      print("Error: \(error.localizedDescription)")
+    }
 
     let template = GenumTemplate(templateString: fixtureString("storyboards-default.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Storyboards-Message-Default.swift.out")
+    let expected = fixtureString("Storyboards-Message-Default.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testMessageStoryboardWithLowercaseTemplate() {
     let parser = StoryboardParser()
-    parser.addStoryboard(at: self.fixturePath("Message.storyboard", subDirectory: StoryboardsDir.iOS))
+    do {
+      try parser.addStoryboard(at: fixture("Message.storyboard", subDirectory: StoryboardsDir.iOS))
+    } catch {
+      print("Error: \(error.localizedDescription)")
+    }
 
     let template = GenumTemplate(templateString: fixtureString("storyboards-lowercase.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Storyboards-Message-Lowercase.swift.out")
+    let expected = fixtureString("Storyboards-Message-Lowercase.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testAnonymousStoryboardWithDefaults() {
     let parser = StoryboardParser()
-    parser.addStoryboard(at: self.fixturePath("Anonymous.storyboard", subDirectory: StoryboardsDir.iOS))
+    do {
+      try parser.addStoryboard(at: fixture("Anonymous.storyboard", subDirectory: StoryboardsDir.iOS))
+    } catch {
+      print("Error: \(error.localizedDescription)")
+    }
 
     let template = GenumTemplate(templateString: fixtureString("storyboards-default.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Storyboards-Anonymous-Default.swift.out")
+    let expected = fixtureString("Storyboards-Anonymous-Default.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testAllStoryboardsWithDefaults() {
     let parser = StoryboardParser()
-    parser.parseDirectory(at: self.fixturesDir(subDirectory: StoryboardsDir.iOS))
+    do {
+      try parser.parseDirectory(at: fixturesDir(subDirectory: StoryboardsDir.iOS))
+    } catch {
+      print("Error: \(error.localizedDescription)")
+    }
 
     let template = GenumTemplate(templateString: fixtureString("storyboards-default.stencil"))
     let ctx = parser.stencilContext()
     let result = try! template.render(ctx)
 
-    let expected = self.fixtureString("Storyboards-All-Default.swift.out")
+    let expected = fixtureString("Storyboards-All-Default.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testAllStoryboardsWithCustomName() {
     let parser = StoryboardParser()
-    parser.parseDirectory(at: self.fixturesDir(subDirectory: StoryboardsDir.iOS))
+    do {
+      try parser.parseDirectory(at: fixturesDir(subDirectory: StoryboardsDir.iOS))
+    } catch {
+      print("Error: \(error.localizedDescription)")
+    }
 
     let template = GenumTemplate(templateString: fixtureString("storyboards-default.stencil"))
     let ctx = parser.stencilContext(sceneEnumName: "XCTStoryboardsScene", segueEnumName: "XCTStoryboardsSegue")
     let result = try! template.render(ctx)
 
-    let expected = self.fixtureString("Storyboards-All-CustomName.swift.out")
+    let expected = fixtureString("Storyboards-All-CustomName.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testAnonymousStoryboardWithSwift3() {
     let parser = StoryboardParser()
-    parser.addStoryboard(at: self.fixturePath("Anonymous.storyboard", subDirectory: StoryboardsDir.iOS))
+    do {
+      try parser.addStoryboard(at: fixture("Anonymous.storyboard", subDirectory: StoryboardsDir.iOS))
+    } catch {
+      print("Error: \(error.localizedDescription)")
+    }
 
     let template = GenumTemplate(templateString: fixtureString("storyboards-swift3.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Storyboards-Anonymous-Swift3.swift.out")
+    let expected = fixtureString("Storyboards-Anonymous-Swift3.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testWizardsStoryboardsWithSwift3() {
     let parser = StoryboardParser()
-    parser.addStoryboard(at: self.fixturePath("Wizard.storyboard", subDirectory: StoryboardsDir.iOS))
+    do {
+      try parser.addStoryboard(at: fixture("Wizard.storyboard", subDirectory: StoryboardsDir.iOS))
+    } catch {
+      print("Error: \(error.localizedDescription)")
+    }
 
     let template = GenumTemplate(templateString: fixtureString("storyboards-swift3.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Storyboards-Wizard-Swift3.swift.out")
+    let expected = fixtureString("Storyboards-Wizard-Swift3.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testAdditionalImport() {
     let parser = StoryboardParser()
-    parser.addStoryboard(at: self.fixturePath("AdditionalImport.storyboard", subDirectory: StoryboardsDir.iOS))
+    do {
+      try parser.addStoryboard(at: fixture("AdditionalImport.storyboard", subDirectory: StoryboardsDir.iOS))
+    } catch {
+      print("Error: \(error.localizedDescription)")
+    }
 
     // additional import statements
     let extraImports = [
@@ -125,7 +157,7 @@ class StoryboardsiOSTests: XCTestCase {
     let context = parser.stencilContext(sceneEnumName: "StoryboardScene", segueEnumName: "StoryboardSegue", extraImports: extraImports)
     let result = try! template.render(context)
 
-    let expected = self.fixtureString("Storyboards-AdditionalImport-Swift3.swift.out")
+    let expected = fixtureString("Storyboards-AdditionalImport-Swift3.swift.out")
     XCTDiffStrings(result, expected)
   }
 }
@@ -140,58 +172,78 @@ class StoryboardsOSXTests: XCTestCase {
     let template = GenumTemplate(templateString: fixtureString("storyboards-osx-default.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Storyboards-osx-Empty.swift.out")
+    let expected = fixtureString("Storyboards-osx-Empty.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testOSXMessageStoryboardWithDefaults() {
     let parser = StoryboardParser()
-    parser.addStoryboard(at: self.fixturePath("Message-osx.storyboard", subDirectory: StoryboardsDir.macOS))
+    do {
+      try parser.addStoryboard(at: fixture("Message-osx.storyboard", subDirectory: StoryboardsDir.macOS))
+    } catch {
+      print("Error: \(error.localizedDescription)")
+    }
 
     let template = GenumTemplate(templateString: fixtureString("storyboards-osx-default.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Storyboards-osx-Message-Default.swift.out")
+    let expected = fixtureString("Storyboards-osx-Message-Default.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testOSXMessageStoryboardWithLowercaseTemplate() {
     let parser = StoryboardParser()
-    parser.addStoryboard(at: self.fixturePath("Message-osx.storyboard", subDirectory: StoryboardsDir.macOS))
+    do {
+      try parser.addStoryboard(at: fixture("Message-osx.storyboard", subDirectory: StoryboardsDir.macOS))
+    } catch {
+      print("Error: \(error.localizedDescription)")
+    }
 
     let template = GenumTemplate(templateString: fixtureString("storyboards-osx-lowercase.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Storyboards-osx-Message-Lowercase.swift.out")
+    let expected = fixtureString("Storyboards-osx-Message-Lowercase.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testOSXAnonymousStoryboardWithDefaults() {
     let parser = StoryboardParser()
-    parser.addStoryboard(at: self.fixturePath("Anonymous-osx.storyboard", subDirectory: StoryboardsDir.macOS))
+    do {
+      try parser.addStoryboard(at: fixture("Anonymous-osx.storyboard", subDirectory: StoryboardsDir.macOS))
+    } catch {
+      print("Error: \(error.localizedDescription)")
+    }
 
     let template = GenumTemplate(templateString: fixtureString("storyboards-osx-default.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Storyboards-osx-Anonymous-Default.swift.out")
+    let expected = fixtureString("Storyboards-osx-Anonymous-Default.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testOSXAllStoryboardsWithDefaults() {
     let parser = StoryboardParser()
-    parser.parseDirectory(at: self.fixturesDir(subDirectory: StoryboardsDir.macOS))
+    do {
+      try parser.parseDirectory(at: fixturesDir(subDirectory: StoryboardsDir.macOS))
+    } catch {
+      print("Error: \(error.localizedDescription)")
+    }
 
     let template = GenumTemplate(templateString: fixtureString("storyboards-osx-default.stencil"))
     let ctx = parser.stencilContext()
     let result = try! template.render(ctx)
 
-    let expected = self.fixtureString("Storyboards-osx-All-Default.swift.out")
+    let expected = fixtureString("Storyboards-osx-All-Default.swift.out")
     XCTDiffStrings(result, expected)
 	}
 
 	func testAdditionalImport() {
 		let parser = StoryboardParser()
-		parser.addStoryboard(at: self.fixturePath("AdditionalImport-osx.storyboard", subDirectory: StoryboardsDir.macOS))
+    do {
+      try parser.addStoryboard(at: fixture("AdditionalImport-osx.storyboard", subDirectory: StoryboardsDir.macOS))
+    } catch {
+      print("Error: \(error.localizedDescription)")
+    }
 
 		// additional import statements
 		let extraImports = [
@@ -202,7 +254,7 @@ class StoryboardsOSXTests: XCTestCase {
 		let context = parser.stencilContext(sceneEnumName: "StoryboardScene", segueEnumName: "StoryboardSegue", extraImports: extraImports)
 		let result = try! template.render(context)
 
-		let expected = self.fixtureString("Storyboards-osx-AdditionalImport-Default.swift.out")
+		let expected = fixtureString("Storyboards-osx-AdditionalImport-Default.swift.out")
 		XCTDiffStrings(result, expected)
 	}
 }

--- a/UnitTests/TestSuites/StringsTests.swift
+++ b/UnitTests/TestSuites/StringsTests.swift
@@ -21,7 +21,7 @@ class StringsTests: XCTestCase {
     let template = GenumTemplate(templateString: fixtureString("strings-default.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Strings-Empty.swift.out")
+    let expected = fixtureString("Strings-Empty.swift.out")
     XCTDiffStrings(result, expected)
   }
 
@@ -33,117 +33,117 @@ class StringsTests: XCTestCase {
     let template = GenumTemplate(templateString: fixtureString("strings-default.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Strings-Entries-Default.swift.out")
+    let expected = fixtureString("Strings-Entries-Default.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testFileWithDefaults() {
     let parser = StringsFileParser()
-    try! parser.parseFile(at :fixturePath("Localizable.strings"))
+    try! parser.parseFile(at: fixture("Localizable.strings"))
 
     let template = GenumTemplate(templateString: fixtureString("strings-default.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Strings-File-Default.swift.out")
+    let expected = fixtureString("Strings-File-Default.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testMultiline() {
     let parser = StringsFileParser()
-    try! parser.parseFile(at: fixturePath("LocMultiline.strings"))
+    try! parser.parseFile(at: fixture("LocMultiline.strings"))
 
     let template = GenumTemplate(templateString: fixtureString("strings-default.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Strings-Multiline.swift.out")
+    let expected = fixtureString("Strings-Multiline.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testUTF8FileWithDefaults() {
     let parser = StringsFileParser()
-    try! parser.parseFile(at: fixturePath("LocUTF8.strings"))
+    try! parser.parseFile(at: fixture("LocUTF8.strings"))
 
     let template = GenumTemplate(templateString: fixtureString("strings-default.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Strings-File-UTF8-Default.swift.out")
+    let expected = fixtureString("Strings-File-UTF8-Default.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testFileWithCustomName() {
     let parser = StringsFileParser()
-    try! parser.parseFile(at: fixturePath("Localizable.strings"))
+    try! parser.parseFile(at: fixture("Localizable.strings"))
 
     let template = GenumTemplate(templateString: fixtureString("strings-default.stencil"))
     let result = try! template.render(parser.stencilContext(enumName: "XCTLoc"))
 
-    let expected = self.fixtureString("Strings-File-CustomName.swift.out")
+    let expected = fixtureString("Strings-File-CustomName.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testFileWithSwift3() {
     let parser = StringsFileParser()
-    try! parser.parseFile(at: fixturePath("Localizable.strings"))
+    try! parser.parseFile(at: fixture("Localizable.strings"))
 
     let template = GenumTemplate(templateString: fixtureString("strings-swift3.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Strings-File-Swift3.swift.out")
+    let expected = fixtureString("Strings-File-Swift3.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testFileWithStructured() {
     let parser = StringsFileParser()
-    try! parser.parseFile(at: fixturePath("Localizable.strings"))
+    try! parser.parseFile(at: fixture("Localizable.strings"))
 
     let template = GenumTemplate(templateString: fixtureString("strings-structured.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Strings-File-Structured.swift.out")
+    let expected = fixtureString("Strings-File-Structured.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testFileWithStructuredOnly() {
     let parser = StringsFileParser()
-    try! parser.parseFile(at: fixturePath("LocStructuredOnly.strings"))
+    try! parser.parseFile(at: fixture("LocStructuredOnly.strings"))
 
     let template = GenumTemplate(templateString: fixtureString("strings-structured.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Strings-File-Structured-Only.swift.out")
+    let expected = fixtureString("Strings-File-Structured-Only.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testFileWithDotSyntax() {
     let parser = StringsFileParser()
-    try! parser.parseFile(at: fixturePath("Localizable.strings"))
+    try! parser.parseFile(at: fixture("Localizable.strings"))
 
     let template = GenumTemplate(templateString: fixtureString("strings-dot-syntax.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Strings-File-Dot-Syntax.swift.out")
+    let expected = fixtureString("Strings-File-Dot-Syntax.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testFileWithDotSyntaxSwift3() {
     let parser = StringsFileParser()
-    try! parser.parseFile(at: fixturePath("Localizable.strings"))
+    try! parser.parseFile(at: fixture("Localizable.strings"))
 
     let template = GenumTemplate(templateString: fixtureString("strings-dot-syntax-swift3.stencil"))
     let result = try! template.render(parser.stencilContext())
 
-    let expected = self.fixtureString("Strings-File-Dot-Syntax-Swift3.swift.out")
+    let expected = fixtureString("Strings-File-Dot-Syntax-Swift3.swift.out")
     XCTDiffStrings(result, expected)
   }
 
   func testFileWithGenstringsTemplate() {
     let parser = StringsFileParser()
-    try! parser.parseFile(at: fixturePath("Localizable.strings"))
+    try! parser.parseFile(at: fixture("Localizable.strings"))
     
     let template = GenumTemplate(templateString: fixtureString("strings-genstrings.stencil"))
     let result = try! template.render(parser.stencilContext())
     
-    let expected = self.fixtureString("Strings-Localizable-Genstrings.swift.out")
+    let expected = fixtureString("Strings-Localizable-Genstrings.swift.out")
     XCTDiffStrings(result, expected)
   }
   

--- a/UnitTests/TestsHelper.swift
+++ b/UnitTests/TestsHelper.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 import XCTest
+import PathKit
 
 private let colorCode: (String) -> String = ProcessInfo().environment["XcodeColors"] == "YES" ? { "\u{001b}[\($0);" } : { _ in "" }
 private let (msgColor, reset) = (colorCode("fg250,0,0"), colorCode(""))
@@ -52,35 +53,33 @@ func XCTDiffStrings(_ result: String, _ expected: String, file: StaticString = #
 }
 
 extension XCTestCase {
-  func fixturesDir(subDirectory subDir: String? = nil) -> String {
+  func fixturesDir(subDirectory subDir: String? = nil) -> Path {
     guard let rsrcURL = Bundle(for: type(of: self)).resourceURL else {
       fatalError("Unable to find resource directory URL")
     }
-    guard let dir = subDir else { return rsrcURL.path }
-    #if swift(>=2.3)
-      return rsrcURL.appendingPathComponent(dir, isDirectory: true).path
-    #else
-      return rsrcURL.URLByAppendingPathComponent(dir, isDirectory: true).path
-    #endif
+    let rsrc = Path(rsrcURL.path)
+
+    guard let dir = subDir else { return rsrc }
+    return rsrc + dir
   }
 
-  func fixturePath(_ name: String, subDirectory: String? = nil) -> String {
+  func fixture(_ name: String, subDirectory: String? = nil) -> Path {
     guard let path = Bundle(for: type(of: self)).path(forResource: name, ofType: "", inDirectory: subDirectory) else {
       fatalError("Unable to find fixture \"\(name)\"")
     }
-    return path
+    return Path(path)
   }
 
-  func directoryPath() -> String {
+  func directory() -> Path {
     guard let path = Bundle(for: type(of: self)).resourcePath else {
       fatalError("Unable to get test bundle resource path")
     }
-    return path
+    return Path(path)
   }
 
   func fixtureString(_ name: String, encoding: String.Encoding = .utf8) -> String {
     do {
-      return try String(contentsOfFile: fixturePath(name), encoding: encoding) as String
+      return try fixture(name).read(encoding)
     } catch let e {
       fatalError("Unable to load fixture content: \(e)")
     }

--- a/swiftgen-cli/colors.swift
+++ b/swiftgen-cli/colors.swift
@@ -16,28 +16,26 @@ let colorsCommand = command(
   Argument<Path>("FILE", description: "Colors.txt|.clr|.xml|.json file to parse.", validator: fileExists)
 ) { output, templateName, templatePath, enumName, path in
 
-  let filePath = String(describing: path)
-
   let parser: ColorsFileParser
-  switch path.`extension` {
+  switch path.extension {
   case "clr"?:
     let clrParser = ColorsCLRFileParser()
-    clrParser.parseFile(at: filePath)
+    clrParser.parseFile(at: path)
     parser = clrParser
   case "txt"?:
     let textParser = ColorsTextFileParser()
-    try textParser.parseFile(at: filePath)
+    try textParser.parseFile(at: path)
     parser = textParser
   case "xml"?:
     let textParser = ColorsXMLFileParser()
-    try textParser.parseFile(at: filePath)
+    try textParser.parseFile(at: path)
     parser = textParser
   case "json"?:
     let textParser = ColorsJSONFileParser()
-    try textParser.parseFile(at: filePath)
+    try textParser.parseFile(at: path)
     parser = textParser
   default:
-    throw ArgumentError.invalidType(value: filePath, type: "CLR, TXT, XML or JSON file", argument: nil)
+		throw ArgumentError.invalidType(value: String(describing: path), type: "CLR, TXT, XML or JSON file", argument: nil)
   }
 
   do {

--- a/swiftgen-cli/fonts.swift
+++ b/swiftgen-cli/fonts.swift
@@ -17,7 +17,7 @@ let fontsCommand = command(
   ) { output, templateName, templatePath, enumName, path in
     let parser = FontsFileParser()
     do {
-      parser.parseFile(at: String(describing: path))
+      parser.parseFile(at: path)
       let templateRealPath = try findTemplate(
         prefix: "fonts", templateShortName: templateName, templateFullPath: templatePath
       )

--- a/swiftgen-cli/images.swift
+++ b/swiftgen-cli/images.swift
@@ -15,7 +15,7 @@ let imagesCommand = command(
   Argument<Path>("DIR", description: "Directory to scan for .imageset files.", validator: dirExists)
 ) { output, templateName, templatePath, enumName, path in
   let parser = AssetsCatalogParser()
-  parser.parseCatalog(at: String(describing: path))
+  parser.parseCatalog(at: path)
 
   do {
     let templateRealPath = try findTemplate(

--- a/swiftgen-cli/storyboards.swift
+++ b/swiftgen-cli/storyboards.swift
@@ -22,13 +22,14 @@ let storyboardsCommand = command(
     validator: pathExists)
 ) { output, templateName, templatePath, sceneEnumName, segueEnumName, extraImports, path in
   let parser = StoryboardParser()
-  if path.`extension` == "storyboard" {
-    parser.addStoryboard(at: String(describing: path))
-  } else {
-    parser.parseDirectory(at: String(describing: path))
-  }
 
   do {
+    if path.extension == "storyboard" {
+      try parser.addStoryboard(at: path)
+    } else {
+      try parser.parseDirectory(at: path)
+    }
+
     let templateRealPath = try findTemplate(
       prefix: "storyboards",
       templateShortName: templateName,
@@ -41,6 +42,6 @@ let storyboardsCommand = command(
     let rendered = try template.render(context)
     output.write(content: rendered, onlyIfChanged: true)
   } catch {
-    printError(string: "error: failed to render template \(error)")
+    printError(string: "error: \(error.localizedDescription)")
   }
 }

--- a/swiftgen-cli/strings.swift
+++ b/swiftgen-cli/strings.swift
@@ -17,7 +17,7 @@ let stringsCommand = command(
   let parser = StringsFileParser()
 
   do {
-    try parser.parseFile(at: String(describing: path))
+    try parser.parseFile(at: path)
 
     let templateRealPath = try findTemplate(
       prefix: "strings", templateShortName: templateName, templateFullPath: templatePath

--- a/swiftgen-cli/templates.swift
+++ b/swiftgen-cli/templates.swift
@@ -25,7 +25,7 @@ let templatesListCommand = command(
   var outputLines = Array<String>()
 
   let printTemplates = { (prefix: String, list: [Path]) in
-    for file in list where file.lastComponent.hasPrefix("\(prefix)-") && file.`extension` == "stencil" {
+    for file in list where file.lastComponent.hasPrefix("\(prefix)-") && file.extension == "stencil" {
       let basename = file.lastComponentWithoutExtension
       let idx = basename.index(basename.startIndex, offsetBy: prefix.characters.count+1)
       let name = basename[idx..<basename.endIndex]


### PR DESCRIPTION
Just did a quick review of places where paths get passed around, and tried to ensure that actual `Path` instances get used there.

The code in FontsFileParser can be simplified further pending https://github.com/kylef/PathKit/pull/25.

Hopefully I haven't missed too many, definitely needs a second look.