### PR TITLE
Fix compile error in swiftgen-cli

### DIFF
--- a/swiftgen-cli/colors.swift
+++ b/swiftgen-cli/colors.swift
@@ -20,7 +20,7 @@ let colorsCommand = command(
   switch path.extension {
   case "clr"?:
     let clrParser = ColorsCLRFileParser()
-    clrParser.parseFile(at: path)
+    try clrParser.parseFile(at: path)
     parser = clrParser
   case "txt"?:
     let textParser = ColorsTextFileParser()


### PR DESCRIPTION
Travis didn't catch this, because it doesn't build the swiftgen target, only the unit tests.