### PR TITLE
Parse storyboard customModule property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ _None_
 * Images: new dot-syntax template, use `dot-syntax-swift3` or `dot-syntax` (for Swift 2.3).  
   [David Jennes](https://github.com/djbe)
   [#206](https://github.com/AliSoftware/SwiftGen/pull/206)
+* Storyboards: automatically detect the correct modules that need to be
+  imported. The `--import` option has therefore been deprecated.  
+  [David Jennes](https://github.com/djbe)
+  [#243](https://github.com/AliSoftware/SwiftGen/pull/243)
 
 ### Internal changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ _None_
   [David Jennes](https://github.com/djbe)
   [#206](https://github.com/AliSoftware/SwiftGen/pull/206)
 * Storyboards: automatically detect the correct modules that need to be
-  imported. The `--import` option has therefore been deprecated.  
+  imported. The `--import` option has therefore been deprecated, as well as the
+  `extraImports` template variable. Instead use the the new `modules` variable,
+   which offers the same functionality.  
   [David Jennes](https://github.com/djbe)
   [#243](https://github.com/AliSoftware/SwiftGen/pull/243)
 

--- a/GenumKit/Parsers/StoryboardParser.swift
+++ b/GenumKit/Parsers/StoryboardParser.swift
@@ -147,7 +147,7 @@ func == (lhs: StoryboardParser.Scene, rhs: StoryboardParser.Scene) -> Bool {
 
 extension StoryboardParser.Scene: Hashable {
   var hashValue: Int {
-    return "\(storyboardID);\(tag);\(customModule);\(customClass)".hashValue
+    return storyboardID.hashValue ^ tag.hashValue ^ (customModule?.hashValue ?? 0) ^ (customClass?.hashValue ?? 0)
   }
 }
 
@@ -160,6 +160,6 @@ func == (lhs: StoryboardParser.Segue, rhs: StoryboardParser.Segue) -> Bool {
 
 extension StoryboardParser.Segue: Hashable {
   var hashValue: Int {
-    return "\(segueID);\(customModule);\(customClass)".hashValue
+    return segueID.hashValue ^ (customModule?.hashValue ?? 0) ^ (customClass?.hashValue ?? 0)
   }
 }

--- a/GenumKit/Parsers/StoryboardParser.swift
+++ b/GenumKit/Parsers/StoryboardParser.swift
@@ -23,7 +23,7 @@ public final class StoryboardParser {
   }
 
   struct Segue {
-    let segueID: String
+    let identifier: String
     let customClass: String?
     let customModule: String?
   }
@@ -77,7 +77,7 @@ public final class StoryboardParser {
         if let segueID = attributeDict["identifier"] {
           let customClass = attributeDict["customClass"]
           let customModule = attributeDict["customModule"]
-          segues.insert(Segue(segueID: segueID, customClass: customClass, customModule: customModule))
+          segues.insert(Segue(identifier: segueID, customClass: customClass, customModule: customModule))
         }
       default:
         break
@@ -153,13 +153,13 @@ extension StoryboardParser.Scene: Hashable {
 
 extension StoryboardParser.Segue: Equatable { }
 func == (lhs: StoryboardParser.Segue, rhs: StoryboardParser.Segue) -> Bool {
-  return lhs.segueID == rhs.segueID &&
+  return lhs.identifier == rhs.identifier &&
     lhs.customClass == rhs.customClass &&
     lhs.customModule == rhs.customModule
 }
 
 extension StoryboardParser.Segue: Hashable {
   var hashValue: Int {
-    return segueID.hashValue ^ (customModule?.hashValue ?? 0) ^ (customClass?.hashValue ?? 0)
+    return identifier.hashValue ^ (customModule?.hashValue ?? 0) ^ (customClass?.hashValue ?? 0)
   }
 }

--- a/GenumKit/Stencil/Contexts.swift
+++ b/GenumKit/Stencil/Contexts.swift
@@ -165,8 +165,7 @@ extension AssetsCatalogParser {
 */
 extension StoryboardParser {
   public func stencilContext(sceneEnumName: String = "StoryboardScene",
-                                           segueEnumName: String = "StoryboardSegue",
-                                           extraImports: [String] = []) -> [String: Any] {
+                                           segueEnumName: String = "StoryboardSegue") -> [String: Any] {
     let storyboards = Set(storyboardsScenes.keys).union(storyboardsSegues.keys).sorted(by: <)
     let storyboardsMap = storyboards.map { (storyboardName: String) -> [String:Any] in
       var sbMap: [String:Any] = ["name": storyboardName]
@@ -174,7 +173,7 @@ extension StoryboardParser {
       if let initialScene = initialScenes[storyboardName] {
         let initial: [String:Any]
         if let customClass = initialScene.customClass {
-          initial = ["customClass": customClass]
+          initial = ["customClass": customClass, "customModule": initialScene.customModule ?? ""]
         } else {
           initial = [
             "baseType": uppercaseFirst(initialScene.tag),
@@ -189,13 +188,17 @@ extension StoryboardParser {
           .sorted(by: {$0.storyboardID < $1.storyboardID})
           .map { (scene: Scene) -> [String:Any] in
             if let customClass = scene.customClass {
-                return ["identifier": scene.storyboardID, "customClass": customClass]
+              return [
+                "identifier": scene.storyboardID,
+                "customClass": customClass,
+                "customModule": scene.customModule ?? ""
+              ]
             } else if scene.tag == "viewController" {
-                return [
-                    "identifier": scene.storyboardID,
-                    "baseType": uppercaseFirst(scene.tag),
-                    "isBaseViewController": scene.tag == "viewController"
-                ]
+              return [
+                "identifier": scene.storyboardID,
+                "baseType": uppercaseFirst(scene.tag),
+                "isBaseViewController": scene.tag == "viewController"
+              ]
             }
             return ["identifier": scene.storyboardID, "baseType": uppercaseFirst(scene.tag)]
         }
@@ -205,7 +208,11 @@ extension StoryboardParser {
         sbMap["segues"] = segues
           .sorted(by: {$0.segueID < $1.segueID})
           .map { (segue: Segue) -> [String:String] in
-            ["identifier": segue.segueID, "customClass": segue.customClass ?? ""]
+            [
+              "identifier": segue.segueID,
+              "customClass": segue.customClass ?? "",
+              "customModule": segue.customModule ?? ""
+            ]
         }
       }
       return sbMap
@@ -213,8 +220,8 @@ extension StoryboardParser {
     return [
       "sceneEnumName": sceneEnumName,
       "segueEnumName": segueEnumName,
-      "extraImports": extraImports,
-      "storyboards": storyboardsMap
+      "storyboards": storyboardsMap,
+      "extraImports": modules.sorted()
     ]
   }
 }

--- a/GenumKit/Stencil/Contexts.swift
+++ b/GenumKit/Stencil/Contexts.swift
@@ -205,15 +205,7 @@ extension StoryboardParser {
       }
       // All Segues
       if let segues = storyboardsSegues[storyboardName] {
-        sbMap["segues"] = segues
-          .sorted(by: {$0.segueID < $1.segueID})
-          .map { (segue: Segue) -> [String:String] in
-            [
-              "identifier": segue.segueID,
-              "customClass": segue.customClass ?? "",
-              "customModule": segue.customModule ?? ""
-            ]
-        }
+        sbMap["segues"] = segues.sorted(by: {$0.identifier < $1.identifier})
       }
       return sbMap
     }

--- a/GenumKit/Stencil/Contexts.swift
+++ b/GenumKit/Stencil/Contexts.swift
@@ -221,7 +221,7 @@ extension StoryboardParser {
       "sceneEnumName": sceneEnumName,
       "segueEnumName": segueEnumName,
       "storyboards": storyboardsMap,
-      "extraImports": modules.sorted()
+      "modules": modules.sorted()
     ]
   }
 }

--- a/GenumKit/Stencil/Contexts.swift
+++ b/GenumKit/Stencil/Contexts.swift
@@ -144,7 +144,7 @@ extension AssetsCatalogParser {
 
  - `sceneEnumName`: `String`
  - `segueEnumName`: `String`
- - `extraImports`: `Array` of `String`
+ - `modules`: `Array` of `String`
  - `storyboards`: `Array` of:
     - `name`: `String`
     - `initialScene`: `Dictionary` (absent if not specified)

--- a/GenumKit/Stencil/Contexts.swift
+++ b/GenumKit/Stencil/Contexts.swift
@@ -221,7 +221,10 @@ extension StoryboardParser {
       "sceneEnumName": sceneEnumName,
       "segueEnumName": segueEnumName,
       "storyboards": storyboardsMap,
-      "modules": modules.sorted()
+      "modules": modules.sorted(),
+
+      // NOTE: This is a deprecated variable
+      "extraImports": modules.sorted()
     ]
   }
 }

--- a/UnitTests/TestSuites/StoryboardsTests.swift
+++ b/UnitTests/TestSuites/StoryboardsTests.swift
@@ -147,15 +147,8 @@ class StoryboardsiOSTests: XCTestCase {
       print("Error: \(error.localizedDescription)")
     }
 
-    // additional import statements
-    let extraImports = [
-      "LocationPicker",
-      "SlackTextViewController"
-    ]
-
     let template = GenumTemplate(templateString: Fixtures.string(for: "storyboards-swift3.stencil"), environment: genumEnvironment())
-    let context = parser.stencilContext(sceneEnumName: "StoryboardScene", segueEnumName: "StoryboardSegue", extraImports: extraImports)
-    let result = try! template.render(context)
+    let result = try! template.render(parser.stencilContext())
 
     let expected = Fixtures.string(for: "Storyboards-AdditionalImport-Swift3.swift.out")
     XCTDiffStrings(result, expected)
@@ -260,14 +253,8 @@ class StoryboardsOSXTests: XCTestCase {
       print("Error: \(error.localizedDescription)")
     }
 
-    // additional import statements
-    let extraImports = [
-      "DBPrefsWindowController"
-    ]
-
     let template = GenumTemplate(templateString: Fixtures.string(for: "storyboards-osx-default.stencil"), environment: genumEnvironment())
-    let context = parser.stencilContext(sceneEnumName: "StoryboardScene", segueEnumName: "StoryboardSegue", extraImports: extraImports)
-    let result = try! template.render(context)
+    let result = try! template.render(parser.stencilContext())
 
     let expected = Fixtures.string(for: "Storyboards-osx-AdditionalImport-Default.swift.out")
     XCTDiffStrings(result, expected)
@@ -280,15 +267,9 @@ class StoryboardsOSXTests: XCTestCase {
     } catch {
       print("Error: \(error.localizedDescription)")
     }
-    
-    // additional import statements
-    let extraImports = [
-      "DBPrefsWindowController"
-    ]
-    
+
     let template = GenumTemplate(templateString: Fixtures.string(for: "storyboards-osx-swift3.stencil"), environment: genumEnvironment())
-    let context = parser.stencilContext(sceneEnumName: "StoryboardScene", segueEnumName: "StoryboardSegue", extraImports: extraImports)
-    let result = try! template.render(context)
+    let result = try! template.render(parser.stencilContext())
     
     let expected = Fixtures.string(for: "Storyboards-osx-AdditionalImport-Swift3.swift.out")
     XCTDiffStrings(result, expected)

--- a/UnitTests/expected/Storyboards-AdditionalImport-Swift3.swift.out
+++ b/UnitTests/expected/Storyboards-AdditionalImport-Swift3.swift.out
@@ -2,6 +2,7 @@
 
 import Foundation
 import UIKit
+import CustomSegue
 import LocationPicker
 import SlackTextViewController
 

--- a/UnitTests/expected/Storyboards-AdditionalImport-Swift3.swift.out
+++ b/UnitTests/expected/Storyboards-AdditionalImport-Swift3.swift.out
@@ -48,18 +48,18 @@ struct StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
 
-    static func initialViewController() -> LocationPickerViewController {
-      guard let vc = storyboard().instantiateInitialViewController() as? LocationPickerViewController else {
+    static func initialViewController() -> LocationPicker.LocationPickerViewController {
+      guard let vc = storyboard().instantiateInitialViewController() as? LocationPicker.LocationPickerViewController else {
         fatalError("Failed to instantiate initialViewController for \(self.storyboardName)")
       }
       return vc
     }
 
     case someSlackViewControllerInstanceScene = "SomeSlackViewControllerInstance"
-    static func instantiateSomeSlackViewControllerInstance() -> SLKTextViewController {
-      guard let vc = StoryboardScene.AdditionalImport.someSlackViewControllerInstanceScene.viewController() as? SLKTextViewController
+    static func instantiateSomeSlackViewControllerInstance() -> SlackTextViewController.SLKTextViewController {
+      guard let vc = StoryboardScene.AdditionalImport.someSlackViewControllerInstanceScene.viewController() as? SlackTextViewController.SLKTextViewController
       else {
-        fatalError("ViewController 'SomeSlackViewControllerInstance' is not of the expected class SLKTextViewController.")
+        fatalError("ViewController 'SomeSlackViewControllerInstance' is not of the expected class SlackTextViewController.SLKTextViewController.")
       }
       return vc
     }

--- a/UnitTests/expected/Storyboards-All-CustomName.swift.out
+++ b/UnitTests/expected/Storyboards-All-CustomName.swift.out
@@ -48,18 +48,18 @@ struct XCTStoryboardsScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
 
-    static func initialViewController() -> LocationPickerViewController {
-      guard let vc = storyboard().instantiateInitialViewController() as? LocationPickerViewController else {
+    static func initialViewController() -> LocationPicker.LocationPickerViewController {
+      guard let vc = storyboard().instantiateInitialViewController() as? LocationPicker.LocationPickerViewController else {
         fatalError("Failed to instantiate initialViewController for \(self.storyboardName)")
       }
       return vc
     }
 
     case SomeSlackViewControllerInstanceScene = "SomeSlackViewControllerInstance"
-    static func instantiateSomeSlackViewControllerInstance() -> SLKTextViewController {
-      guard let vc = XCTStoryboardsScene.AdditionalImport.SomeSlackViewControllerInstanceScene.viewController() as? SLKTextViewController
+    static func instantiateSomeSlackViewControllerInstance() -> SlackTextViewController.SLKTextViewController {
+      guard let vc = XCTStoryboardsScene.AdditionalImport.SomeSlackViewControllerInstanceScene.viewController() as? SlackTextViewController.SLKTextViewController
       else {
-        fatalError("ViewController 'SomeSlackViewControllerInstance' is not of the expected class SLKTextViewController.")
+        fatalError("ViewController 'SomeSlackViewControllerInstance' is not of the expected class SlackTextViewController.SLKTextViewController.")
       }
       return vc
     }

--- a/UnitTests/expected/Storyboards-All-CustomName.swift.out
+++ b/UnitTests/expected/Storyboards-All-CustomName.swift.out
@@ -2,6 +2,9 @@
 
 import Foundation
 import UIKit
+import CustomSegue
+import LocationPicker
+import SlackTextViewController
 
 // swiftlint:disable file_length
 // swiftlint:disable line_length
@@ -167,6 +170,9 @@ struct XCTStoryboardsScene {
 }
 
 struct XCTStoryboardsSegue {
+  enum AdditionalImport: String, StoryboardSegueType {
+    case Test = "test"
+  }
   enum Message: String, StoryboardSegueType {
     case CustomBack = "CustomBack"
     case Embed = "Embed"

--- a/UnitTests/expected/Storyboards-All-Default.swift.out
+++ b/UnitTests/expected/Storyboards-All-Default.swift.out
@@ -48,18 +48,18 @@ struct StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
 
-    static func initialViewController() -> LocationPickerViewController {
-      guard let vc = storyboard().instantiateInitialViewController() as? LocationPickerViewController else {
+    static func initialViewController() -> LocationPicker.LocationPickerViewController {
+      guard let vc = storyboard().instantiateInitialViewController() as? LocationPicker.LocationPickerViewController else {
         fatalError("Failed to instantiate initialViewController for \(self.storyboardName)")
       }
       return vc
     }
 
     case SomeSlackViewControllerInstanceScene = "SomeSlackViewControllerInstance"
-    static func instantiateSomeSlackViewControllerInstance() -> SLKTextViewController {
-      guard let vc = StoryboardScene.AdditionalImport.SomeSlackViewControllerInstanceScene.viewController() as? SLKTextViewController
+    static func instantiateSomeSlackViewControllerInstance() -> SlackTextViewController.SLKTextViewController {
+      guard let vc = StoryboardScene.AdditionalImport.SomeSlackViewControllerInstanceScene.viewController() as? SlackTextViewController.SLKTextViewController
       else {
-        fatalError("ViewController 'SomeSlackViewControllerInstance' is not of the expected class SLKTextViewController.")
+        fatalError("ViewController 'SomeSlackViewControllerInstance' is not of the expected class SlackTextViewController.SLKTextViewController.")
       }
       return vc
     }

--- a/UnitTests/expected/Storyboards-All-Default.swift.out
+++ b/UnitTests/expected/Storyboards-All-Default.swift.out
@@ -2,6 +2,9 @@
 
 import Foundation
 import UIKit
+import CustomSegue
+import LocationPicker
+import SlackTextViewController
 
 // swiftlint:disable file_length
 // swiftlint:disable line_length
@@ -167,6 +170,9 @@ struct StoryboardScene {
 }
 
 struct StoryboardSegue {
+  enum AdditionalImport: String, StoryboardSegueType {
+    case Test = "test"
+  }
   enum Message: String, StoryboardSegueType {
     case CustomBack = "CustomBack"
     case Embed = "Embed"

--- a/UnitTests/expected/Storyboards-osx-AdditionalImport-Default.swift.out
+++ b/UnitTests/expected/Storyboards-osx-AdditionalImport-Default.swift.out
@@ -54,10 +54,10 @@ struct StoryboardScene {
     static let storyboardName = "AdditionalImport-osx"
 
     case PreferencesScene = "Preferences"
-    static func instantiatePreferences() -> DBPrefsWindowController {
-      guard let vc = StoryboardScene.AdditionalImport_Osx.PreferencesScene.controller() as? DBPrefsWindowController
+    static func instantiatePreferences() -> DBPrefsWindowController.DBPrefsWindowController {
+      guard let vc = StoryboardScene.AdditionalImport_Osx.PreferencesScene.controller() as? DBPrefsWindowController.DBPrefsWindowController
       else {
-        fatalError("ViewController 'Preferences' is not of the expected class DBPrefsWindowController.")
+        fatalError("ViewController 'Preferences' is not of the expected class DBPrefsWindowController.DBPrefsWindowController.")
       }
       return vc
     }

--- a/UnitTests/expected/Storyboards-osx-AdditionalImport-Swift3.swift.out
+++ b/UnitTests/expected/Storyboards-osx-AdditionalImport-Swift3.swift.out
@@ -54,10 +54,10 @@ struct StoryboardScene {
     static let storyboardName = "AdditionalImport-osx"
 
     case preferencesScene = "Preferences"
-    static func instantiatePreferences() -> DBPrefsWindowController {
-      guard let vc = StoryboardScene.AdditionalImport_Osx.preferencesScene.controller() as? DBPrefsWindowController
+    static func instantiatePreferences() -> DBPrefsWindowController.DBPrefsWindowController {
+      guard let vc = StoryboardScene.AdditionalImport_Osx.preferencesScene.controller() as? DBPrefsWindowController.DBPrefsWindowController
       else {
-        fatalError("ViewController 'Preferences' is not of the expected class DBPrefsWindowController.")
+        fatalError("ViewController 'Preferences' is not of the expected class DBPrefsWindowController.DBPrefsWindowController.")
       }
       return vc
     }

--- a/UnitTests/expected/Storyboards-osx-All-Default.swift.out
+++ b/UnitTests/expected/Storyboards-osx-All-Default.swift.out
@@ -54,10 +54,10 @@ struct StoryboardScene {
     static let storyboardName = "AdditionalImport-osx"
 
     case PreferencesScene = "Preferences"
-    static func instantiatePreferences() -> DBPrefsWindowController {
-      guard let vc = StoryboardScene.AdditionalImport_Osx.PreferencesScene.controller() as? DBPrefsWindowController
+    static func instantiatePreferences() -> DBPrefsWindowController.DBPrefsWindowController {
+      guard let vc = StoryboardScene.AdditionalImport_Osx.PreferencesScene.controller() as? DBPrefsWindowController.DBPrefsWindowController
       else {
-        fatalError("ViewController 'Preferences' is not of the expected class DBPrefsWindowController.")
+        fatalError("ViewController 'Preferences' is not of the expected class DBPrefsWindowController.DBPrefsWindowController.")
       }
       return vc
     }

--- a/UnitTests/expected/Storyboards-osx-All-Default.swift.out
+++ b/UnitTests/expected/Storyboards-osx-All-Default.swift.out
@@ -2,6 +2,7 @@
 
 import Foundation
 import Cocoa
+import DBPrefsWindowController
 
 // swiftlint:disable file_length
 // swiftlint:disable line_length

--- a/UnitTests/fixtures/Storyboards-OSX/AdditionalImport-osx.storyboard
+++ b/UnitTests/fixtures/Storyboards-OSX/AdditionalImport-osx.storyboard
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11542"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
     </dependencies>
     <scenes>
         <!--Window Controller-->
         <scene sceneID="eNa-6E-hop">
             <objects>
-                <windowController storyboardIdentifier="Preferences" id="3Gn-1I-HiJ" customClass="DBPrefsWindowController" sceneMemberID="viewController">
+                <windowController storyboardIdentifier="Preferences" id="3Gn-1I-HiJ" customClass="DBPrefsWindowController" customModule="DBPrefsWindowController" sceneMemberID="viewController">
                     <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="sw7-rd-HiT">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>

--- a/UnitTests/fixtures/Storyboards-iOS/AdditionalImport.storyboard
+++ b/UnitTests/fixtures/Storyboards-iOS/AdditionalImport.storyboard
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="sCq-1b-U1T">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="sCq-1b-U1T">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Location Picker View Controller-->
         <scene sceneID="1iN-a4-Pl6">
             <objects>
-                <viewController id="sCq-1b-U1T" customClass="LocationPickerViewController" sceneMemberID="viewController">
+                <viewController id="sCq-1b-U1T" customClass="LocationPickerViewController" customModule="LocationPicker" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="AF1-Pm-1gV"/>
                         <viewControllerLayoutGuide type="bottom" id="E3P-fP-oWf"/>
@@ -23,6 +23,9 @@
                     </view>
                     <navigationItem key="navigationItem" id="KZX-mS-tuT"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+                    <connections>
+                        <segue destination="TuC-8Y-xZ9" kind="custom" identifier="test" customClass="SlideDownSegue" customModule="CustomSegue" id="Ac7-Re-xKv"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="v2R-VI-fT0" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -31,7 +34,7 @@
         <!--Text View Controller-->
         <scene sceneID="yg3-tg-GNr">
             <objects>
-                <viewController storyboardIdentifier="SomeSlackViewControllerInstance" id="TuC-8Y-xZ9" customClass="SLKTextViewController" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="SomeSlackViewControllerInstance" id="TuC-8Y-xZ9" customClass="SLKTextViewController" customModule="SlackTextViewController" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="M6w-YY-zkB"/>
                         <viewControllerLayoutGuide type="bottom" id="DvD-4b-cvd"/>

--- a/swiftgen-cli/storyboards.swift
+++ b/swiftgen-cli/storyboards.swift
@@ -15,8 +15,9 @@ let storyboardsCommand = command(
     description: "The name of the enum to generate for Scenes"),
   Option<String>("segueEnumName", "StoryboardSegue", flag: "g",
     description: "The name of the enum to generate for Segues"),
+  // Note: import option is deprecated.
   VariadicOption<String>("import", [],
-    description: "Additional imports to be added to the generated file"),
+    description: "Additional imports to be added to the generated file (DEPRECATED)"),
   VariadicArgument<Path>("PATH",
     description: "Directory to scan for .storyboard files. Can also be a path to a single .storyboard",
     validator: pathsExist)
@@ -39,7 +40,7 @@ let storyboardsCommand = command(
     )
     let template = try GenumTemplate(templateString: templateRealPath.read(), environment: genumEnvironment())
     let context = parser.stencilContext(
-      sceneEnumName: sceneEnumName, segueEnumName: segueEnumName, extraImports: extraImports
+      sceneEnumName: sceneEnumName, segueEnumName: segueEnumName
     )
     let rendered = try template.render(context)
     output.write(content: rendered, onlyIfChanged: true)

--- a/templates/storyboards-default.stencil
+++ b/templates/storyboards-default.stencil
@@ -54,7 +54,7 @@ struct {{sceneEnumName}} {
   enum {{storyboardName}}: String, StoryboardSceneType {
     static let storyboardName = "{{storyboard.name}}"
     {% if storyboard.initialScene %}{% ifnot storyboard.initialScene.isBaseViewController %}
-    {% set initialSceneClass %}{% if storyboard.initialScene.customClass %}{{storyboard.initialScene.customClass}}{% else %}UI{{storyboard.initialScene.baseType}}{% endif %}{% endset %}
+    {% set initialSceneClass %}{% if storyboard.initialScene.customClass %}{% if storyboard.initialScene.customModule %}{{storyboard.initialScene.customModule}}.{% endif %}{{storyboard.initialScene.customClass}}{% else %}UI{{storyboard.initialScene.baseType}}{% endif %}{% endset %}
 
     static func initialViewController() -> {{initialSceneClass}} {
       guard let vc = storyboard().instantiateInitialViewController() as? {{initialSceneClass}} else {
@@ -69,10 +69,10 @@ struct {{sceneEnumName}} {
     case {{sceneID}}Scene = "{{scene.identifier}}"
     {% ifnot scene.isBaseViewController %}
     {% if scene.customClass %}
-    static func instantiate{{sceneID|snakeToCamelCase}}() -> {{scene.customClass}} {
-      guard let vc = {{sceneEnumName}}.{{storyboardName}}.{{sceneID}}Scene.viewController() as? {{scene.customClass}}
+    static func instantiate{{sceneID|snakeToCamelCase}}() -> {% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}} {
+      guard let vc = {{sceneEnumName}}.{{storyboardName}}.{{sceneID}}Scene.viewController() as? {% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}
       else {
-        fatalError("ViewController '{{scene.identifier}}' is not of the expected class {{scene.customClass}}.")
+        fatalError("ViewController '{{scene.identifier}}' is not of the expected class {% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}.")
       }
       return vc
     }
@@ -96,7 +96,7 @@ struct {{sceneEnumName}} {
   enum {{storyboardName}}: StoryboardSceneType {
     static let storyboardName = "{{storyboard.name}}"
     {% if storyboard.initialScene %}{% ifnot storyboard.initialScene.isBaseViewController %}
-    {% set initialSceneClass %}{% if storyboard.initialScene.customClass %}{{storyboard.initialScene.customClass}}{% else %}UI{{storyboard.initialScene.baseType}}{% endif %}{% endset %}
+    {% set initialSceneClass %}{% if storyboard.initialScene.customClass %}{% if storyboard.initialScene.customModule %}{{storyboard.initialScene.customModule}}.{% endif %}{{storyboard.initialScene.customClass}}{% else %}UI{{storyboard.initialScene.baseType}}{% endif %}{% endset %}
 
     static func initialViewController() -> {{initialSceneClass}} {
       guard let vc = storyboard().instantiateInitialViewController() as? {{initialSceneClass}} else {

--- a/templates/storyboards-default.stencil
+++ b/templates/storyboards-default.stencil
@@ -2,8 +2,8 @@
 
 import Foundation
 import UIKit
-{% for import in extraImports %}
-import {{import}}
+{% for module in modules %}
+import {{module}}
 {% endfor %}
 
 // swiftlint:disable file_length

--- a/templates/storyboards-lowercase.stencil
+++ b/templates/storyboards-lowercase.stencil
@@ -54,7 +54,7 @@ struct {{sceneEnumName}} {
   enum {{storyboardName}}: String, StoryboardSceneType {
     static let storyboardName = "{{storyboard.name}}"
     {% if storyboard.initialScene %}{% ifnot storyboard.initialScene.isBaseViewController %}
-    {% set initialSceneClass %}{% if storyboard.initialScene.customClass %}{{storyboard.initialScene.customClass}}{% else %}UI{{storyboard.initialScene.baseType}}{% endif %}{% endset %}
+    {% set initialSceneClass %}{% if storyboard.initialScene.customClass %}{% if storyboard.initialScene.customModule %}{{storyboard.initialScene.customModule}}.{% endif %}{{storyboard.initialScene.customClass}}{% else %}UI{{storyboard.initialScene.baseType}}{% endif %}{% endset %}
 
     static func initialViewController() -> {{initialSceneClass}} {
       guard let vc = storyboard().instantiateInitialViewController() as? {{initialSceneClass}} else {
@@ -69,10 +69,10 @@ struct {{sceneEnumName}} {
     case {{sceneID}} = "{{scene.identifier}}"
     {% ifnot scene.isBaseViewController %}
     {% if scene.customClass %}
-    static func {{sceneID}}ViewController() -> {{scene.customClass}} {
-      guard let vc = {{sceneEnumName}}.{{storyboardName}}.{{sceneID}}.viewController() as? {{scene.customClass}}
+    static func {{sceneID}}ViewController() -> {% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}} {
+      guard let vc = {{sceneEnumName}}.{{storyboardName}}.{{sceneID}}.viewController() as? {% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}
       else {
-        fatalError("ViewController '{{scene.identifier}}' is not of the expected class {{scene.customClass}}.")
+        fatalError("ViewController '{{scene.identifier}}' is not of the expected class {% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}.")
       }
       return vc
     }
@@ -96,7 +96,7 @@ struct {{sceneEnumName}} {
   enum {{storyboardName}}: StoryboardSceneType {
     static let storyboardName = "{{storyboard.name}}"
     {% if storyboard.initialScene %}{% ifnot storyboard.initialScene.isBaseViewController %}
-    {% set initialSceneClass %}{% if storyboard.initialScene.customClass %}{{storyboard.initialScene.customClass}}{% else %}UI{{storyboard.initialScene.baseType}}{% endif %}{% endset %}
+    {% set initialSceneClass %}{% if storyboard.initialScene.customClass %}{% if storyboard.initialScene.customModule %}{{storyboard.initialScene.customModule}}.{% endif %}{{storyboard.initialScene.customClass}}{% else %}UI{{storyboard.initialScene.baseType}}{% endif %}{% endset %}
 
     static func initialViewController() -> {{initialSceneClass}} {
       guard let vc = storyboard().instantiateInitialViewController() as? {{initialSceneClass}} else {

--- a/templates/storyboards-lowercase.stencil
+++ b/templates/storyboards-lowercase.stencil
@@ -2,8 +2,8 @@
 
 import Foundation
 import UIKit
-{% for import in extraImports %}
-import {{import}}
+{% for module in modules %}
+import {{module}}
 {% endfor %}
 
 // swiftlint:disable file_length

--- a/templates/storyboards-osx-default.stencil
+++ b/templates/storyboards-osx-default.stencil
@@ -65,10 +65,10 @@ struct {{sceneEnumName}} {
 
     case {{sceneID}}Scene = "{{scene.identifier}}"
     {% if scene.customClass %}
-    static func instantiate{{sceneID|snakeToCamelCase}}() -> {{scene.customClass}} {
-      guard let vc = {{sceneEnumName}}.{{storyboardName}}.{{sceneID}}Scene.controller() as? {{scene.customClass}}
+    static func instantiate{{sceneID|snakeToCamelCase}}() -> {% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}} {
+      guard let vc = {{sceneEnumName}}.{{storyboardName}}.{{sceneID}}Scene.controller() as? {% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}
       else {
-        fatalError("ViewController '{{scene.identifier}}' is not of the expected class {{scene.customClass}}.")
+        fatalError("ViewController '{{scene.identifier}}' is not of the expected class {% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}.")
       }
       return vc
     }

--- a/templates/storyboards-osx-default.stencil
+++ b/templates/storyboards-osx-default.stencil
@@ -2,8 +2,8 @@
 
 import Foundation
 import Cocoa
-{% for import in extraImports %}
-import {{import}}
+{% for module in modules %}
+import {{module}}
 {% endfor %}
 
 // swiftlint:disable file_length

--- a/templates/storyboards-osx-lowercase.stencil
+++ b/templates/storyboards-osx-lowercase.stencil
@@ -65,10 +65,10 @@ struct {{sceneEnumName}} {
 
     case {{sceneID}}Scene = "{{scene.identifier}}"
     {% if scene.customClass %}
-    static func instantiate{{sceneID||snakeToCamelCase}}() -> {{scene.customClass}} {
-      guard let vc = {{sceneEnumName}}.{{storyboardName}}.{{sceneID}}Scene.controller() as? {{scene.customClass}}
+    static func instantiate{{sceneID||snakeToCamelCase}}() -> {% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}} {
+      guard let vc = {{sceneEnumName}}.{{storyboardName}}.{{sceneID}}Scene.controller() as? {% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}
       else {
-        fatalError("ViewController '{{scene.identifier}}' is not of the expected class {{scene.customClass}}.")
+        fatalError("ViewController '{{scene.identifier}}' is not of the expected class {% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}.")
       }
       return vc
     }

--- a/templates/storyboards-osx-lowercase.stencil
+++ b/templates/storyboards-osx-lowercase.stencil
@@ -2,8 +2,8 @@
 
 import Foundation
 import Cocoa
-{% for import in extraImports %}
-import {{import}}
+{% for module in modules %}
+import {{module}}
 {% endfor %}
 
 // swiftlint:disable file_length

--- a/templates/storyboards-osx-swift3.stencil
+++ b/templates/storyboards-osx-swift3.stencil
@@ -65,10 +65,10 @@ struct {{sceneEnumName}} {
 
     case {{sceneID}}Scene = "{{scene.identifier}}"
     {% if scene.customClass %}
-    static func instantiate{{sceneID||snakeToCamelCase}}() -> {{scene.customClass}} {
-      guard let vc = {{sceneEnumName}}.{{storyboardName}}.{{sceneID}}Scene.controller() as? {{scene.customClass}}
+    static func instantiate{{sceneID||snakeToCamelCase}}() -> {% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}} {
+      guard let vc = {{sceneEnumName}}.{{storyboardName}}.{{sceneID}}Scene.controller() as? {% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}
       else {
-        fatalError("ViewController '{{scene.identifier}}' is not of the expected class {{scene.customClass}}.")
+        fatalError("ViewController '{{scene.identifier}}' is not of the expected class {% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}.")
       }
       return vc
     }

--- a/templates/storyboards-osx-swift3.stencil
+++ b/templates/storyboards-osx-swift3.stencil
@@ -2,8 +2,8 @@
 
 import Foundation
 import Cocoa
-{% for import in extraImports %}
-import {{import}}
+{% for module in modules %}
+import {{module}}
 {% endfor %}
 
 // swiftlint:disable file_length

--- a/templates/storyboards-swift3.stencil
+++ b/templates/storyboards-swift3.stencil
@@ -54,7 +54,7 @@ struct {{sceneEnumName}} {
   enum {{storyboardName}}: String, StoryboardSceneType {
     static let storyboardName = "{{storyboard.name}}"
     {% if storyboard.initialScene %}{% ifnot storyboard.initialScene.isBaseViewController %}
-    {% set initialSceneClass %}{% if storyboard.initialScene.customClass %}{{storyboard.initialScene.customClass}}{% else %}UI{{storyboard.initialScene.baseType}}{% endif %}{% endset %}
+    {% set initialSceneClass %}{% if storyboard.initialScene.customClass %}{% if storyboard.initialScene.customModule %}{{storyboard.initialScene.customModule}}.{% endif %}{{storyboard.initialScene.customClass}}{% else %}UI{{storyboard.initialScene.baseType}}{% endif %}{% endset %}
 
     static func initialViewController() -> {{initialSceneClass}} {
       guard let vc = storyboard().instantiateInitialViewController() as? {{initialSceneClass}} else {
@@ -69,10 +69,10 @@ struct {{sceneEnumName}} {
     case {{sceneID}}Scene = "{{scene.identifier}}"
     {% ifnot scene.isBaseViewController %}
     {% if scene.customClass %}
-    static func instantiate{{sceneID|titlecase}}() -> {{scene.customClass}} {
-      guard let vc = {{sceneEnumName}}.{{storyboardName}}.{{sceneID}}Scene.viewController() as? {{scene.customClass}}
+    static func instantiate{{sceneID|titlecase}}() -> {% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}} {
+      guard let vc = {{sceneEnumName}}.{{storyboardName}}.{{sceneID}}Scene.viewController() as? {% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}
       else {
-        fatalError("ViewController '{{scene.identifier}}' is not of the expected class {{scene.customClass}}.")
+        fatalError("ViewController '{{scene.identifier}}' is not of the expected class {% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}.")
       }
       return vc
     }
@@ -96,7 +96,7 @@ struct {{sceneEnumName}} {
   enum {{storyboardName}}: StoryboardSceneType {
     static let storyboardName = "{{storyboard.name}}"
     {% if storyboard.initialScene %}{% ifnot storyboard.initialScene.isBaseViewController %}
-    {% set initialSceneClass %}{% if storyboard.initialScene.customClass %}{{storyboard.initialScene.customClass}}{% else %}UI{{storyboard.initialScene.baseType}}{% endif %}{% endset %}
+    {% set initialSceneClass %}{% if storyboard.initialScene.customClass %}{% if storyboard.initialScene.customModule %}{{storyboard.initialScene.customModule}}.{% endif %}{{storyboard.initialScene.customClass}}{% else %}UI{{storyboard.initialScene.baseType}}{% endif %}{% endset %}
 
     static func initialViewController() -> {{initialSceneClass}} {
       guard let vc = storyboard().instantiateInitialViewController() as? {{initialSceneClass}} else {

--- a/templates/storyboards-swift3.stencil
+++ b/templates/storyboards-swift3.stencil
@@ -2,8 +2,8 @@
 
 import Foundation
 import UIKit
-{% for import in extraImports %}
-import {{import}}
+{% for module in modules %}
+import {{module}}
 {% endfor %}
 
 // swiftlint:disable file_length

--- a/templates/storyboards-uppercase.stencil
+++ b/templates/storyboards-uppercase.stencil
@@ -54,7 +54,7 @@ struct {{sceneEnumName}} {
   enum {{storyboardName}}: String, StoryboardSceneType {
     static let storyboardName = "{{storyboard.name}}"
     {% if storyboard.initialScene %}{% ifnot storyboard.initialScene.isBaseViewController %}
-    {% set initialSceneClass %}{% if storyboard.initialScene.customClass %}{{storyboard.initialScene.customClass}}{% else %}UI{{storyboard.initialScene.baseType}}{% endif %}{% endset %}
+    {% set initialSceneClass %}{% if storyboard.initialScene.customClass %}{% if storyboard.initialScene.customModule %}{{storyboard.initialScene.customModule}}.{% endif %}{{storyboard.initialScene.customClass}}{% else %}UI{{storyboard.initialScene.baseType}}{% endif %}{% endset %}
 
     static func initialViewController() -> {{initialSceneClass}} {
       guard let vc = storyboard().instantiateInitialViewController() as? {{initialSceneClass}} else {
@@ -69,10 +69,10 @@ struct {{sceneEnumName}} {
     case {{sceneID}} = "{{scene.identifier}}"
     {% ifnot scene.isBaseViewController %}
     {% if scene.customClass %}
-    static func {{sceneID|snakeToCamelCase|lowerFirstWord}}ViewController() -> {{scene.customClass}} {
-      guard let vc = {{sceneEnumName}}.{{storyboardName}}.{{sceneID}}.viewController() as? {{scene.customClass}}
+    static func {{sceneID|snakeToCamelCase|lowerFirstWord}}ViewController() -> {% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}} {
+      guard let vc = {{sceneEnumName}}.{{storyboardName}}.{{sceneID}}.viewController() as? {% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}
       else {
-        fatalError("ViewController '{{scene.identifier}}' is not of the expected class {{scene.customClass}}.")
+        fatalError("ViewController '{{scene.identifier}}' is not of the expected class {% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}.")
       }
       return vc
     }
@@ -96,7 +96,7 @@ struct {{sceneEnumName}} {
   enum {{storyboardName}}: StoryboardSceneType {
     static let storyboardName = "{{storyboard.name}}"
     {% if storyboard.initialScene %}{% ifnot storyboard.initialScene.isBaseViewController %}
-    {% set initialSceneClass %}{% if storyboard.initialScene.customClass %}{{storyboard.initialScene.customClass}}{% else %}UI{{storyboard.initialScene.baseType}}{% endif %}{% endset %}
+    {% set initialSceneClass %}{% if storyboard.initialScene.customClass %}{% if storyboard.initialScene.customModule %}{{storyboard.initialScene.customModule}}.{% endif %}{{storyboard.initialScene.customClass}}{% else %}UI{{storyboard.initialScene.baseType}}{% endif %}{% endset %}
 
     static func initialViewController() -> {{initialSceneClass}} {
       guard let vc = storyboard().instantiateInitialViewController() as? {{initialSceneClass}} else {

--- a/templates/storyboards-uppercase.stencil
+++ b/templates/storyboards-uppercase.stencil
@@ -2,8 +2,8 @@
 
 import Foundation
 import UIKit
-{% for import in extraImports %}
-import {{import}}
+{% for module in modules %}
+import {{module}}
 {% endfor %}
 
 // swiftlint:disable file_length


### PR DESCRIPTION
This deprecates the `--import` option.

As a bonus, this fixes an issue where a user could have a class name collision with classes from modules.