### PR TITLE
Strings dot-syntax-swift3 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Bug Fixes
 
 * Strings: fix issue with `dot-syntax-swift3` where function definitions were
-  not swift3 guidelines compliant.  
+  not Swift 3 guidelines compliant.  
   [David Jennes](https://github.com/djbe)
   [#248](https://github.com/AliSoftware/SwiftGen/pull/248)
 
@@ -94,7 +94,7 @@
 * Fix swift 3 storyboard templates to be compliant with swift 3 api design guidelines.  
   [Afonso](https://github.com/afonsograca)
   [#194](https://github.com/AliSoftware/SwiftGen/pull/194)
-* Remove the `key` param label from the `tr` function for Localized String in the swift3 template.  
+* Remove the `key` param label from the `tr` function for Localized String in the Swift 3 template.  
   [AndrewSB](https://github.com/AndrewSB)
   [#190](https://github.com/AliSoftware/SwiftGen/pull/190)
 * The `swiftgen images` command now uses the `actool` utility to parse asset catalogs,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@
 
 ### Bug Fixes
 
-_None_
+* Strings: fix issue with `dot-syntax-swift3` where function definitions were
+  not swift3 guidelines compliant.  
+  [David Jennes](https://github.com/djbe)
+  [#248](https://github.com/AliSoftware/SwiftGen/pull/248)
 
 ### New Features
 

--- a/UnitTests/expected/Strings-File-Dot-Syntax-Swift3.swift.out
+++ b/UnitTests/expected/Strings-File-Dot-Syntax-Swift3.swift.out
@@ -16,25 +16,25 @@ enum L10n {
   /// Title of the alert
   static let alertTitle = L10n.tr("alert_title")
   /// Hello, my name is %@ and I'm %d
-  static func greetings(p0: String, p1: Int) -> String {
-    return L10n.tr("greetings", p0, p1)
+  static func greetings(_ p1: String, _ p2: Int) -> String {
+    return L10n.tr("greetings", p1, p2)
   }
   /// These are %3$@'s %1$d %2$@.
-  static func objectOwnership(p0: Int, p1: String, p2: String) -> String {
-    return L10n.tr("ObjectOwnership", p0, p1, p2)
+  static func objectOwnership(_ p1: Int, _ p2: String, _ p3: String) -> String {
+    return L10n.tr("ObjectOwnership", p1, p2, p3)
   }
 
   enum Apples {
     /// You have %d apples
-    static func count(p0: Int) -> String {
-      return L10n.tr("apples.count", p0)
+    static func count(_ p1: Int) -> String {
+      return L10n.tr("apples.count", p1)
     }
   }
 
   enum Bananas {
     /// Those %d bananas belong to %@.
-    static func owner(p0: Int, p1: String) -> String {
-      return L10n.tr("bananas.owner", p0, p1)
+    static func owner(_ p1: Int, _ p2: String) -> String {
+      return L10n.tr("bananas.owner", p1, p2)
     }
   }
 

--- a/templates/strings-dot-syntax-swift3.stencil
+++ b/templates/strings-dot-syntax-swift3.stencil
@@ -10,12 +10,14 @@ import Foundation
 // swiftlint:disable nesting
 // swiftlint:disable variable_name
 // swiftlint:disable valid_docs
+{% macro parametersBlock params %}{% for type in params.types %}_ p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
+{% macro argumentsBlock params %}{% for type in params.types %}p{{forloop.counter}}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
 {% macro recursiveBlock strings sp %}
 {{sp}}  {% for string in strings.strings %}
 {{sp}}  /// {{string.translation}}
 {{sp}}  {% if string.params %}
-{{sp}}  static func {{string.keytail|swiftIdentifier|titlecase|snakeToCamelCase|lowerFirstWord|escapeReservedKeywords}}({{string.params.typednames|join}}) -> String {
-{{sp}}    return {{enumName}}.tr("{{string.key}}", {{string.params.names|join}})
+{{sp}}  static func {{string.keytail|swiftIdentifier|titlecase|snakeToCamelCase|lowerFirstWord|escapeReservedKeywords}}({% call parametersBlock string.params %}) -> String {
+{{sp}}    return {{enumName}}.tr("{{string.key}}", {% call argumentsBlock string.params %})
 {{sp}}  }
 {{sp}}  {% else %}
 {{sp}}  static let {{string.keytail|swiftIdentifier|titlecase|snakeToCamelCase|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{string.key}}")


### PR DESCRIPTION
Fixes #241, is also an example on how to get rid of the `p0`, `p1` variables.