### PR TITLE
Strings: added explicit bundle parameter to NSLocalizedString calls to support frameworks

### DIFF
--- a/UnitTests/expected/Strings-Entries-Default.swift.out
+++ b/UnitTests/expected/Strings-Entries-Default.swift.out
@@ -27,7 +27,7 @@ extension L10n: CustomStringConvertible {
   }
 
   private static func tr(key: String, _ args: CVarArgType...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
@@ -35,3 +35,5 @@ extension L10n: CustomStringConvertible {
 func tr(key: L10n) -> String {
   return key.string
 }
+
+private final class BundleToken {}

--- a/UnitTests/expected/Strings-File-CustomName.swift.out
+++ b/UnitTests/expected/Strings-File-CustomName.swift.out
@@ -63,7 +63,7 @@ extension XCTLoc: CustomStringConvertible {
   }
 
   private static func tr(key: String, _ args: CVarArgType...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
@@ -71,3 +71,5 @@ extension XCTLoc: CustomStringConvertible {
 func tr(key: XCTLoc) -> String {
   return key.string
 }
+
+private final class BundleToken {}

--- a/UnitTests/expected/Strings-File-Default.swift.out
+++ b/UnitTests/expected/Strings-File-Default.swift.out
@@ -63,7 +63,7 @@ extension L10n: CustomStringConvertible {
   }
 
   private static func tr(key: String, _ args: CVarArgType...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
@@ -71,3 +71,5 @@ extension L10n: CustomStringConvertible {
 func tr(key: L10n) -> String {
   return key.string
 }
+
+private final class BundleToken {}

--- a/UnitTests/expected/Strings-File-Dot-Syntax-Swift3.swift.out
+++ b/UnitTests/expected/Strings-File-Dot-Syntax-Swift3.swift.out
@@ -78,10 +78,12 @@ enum L10n {
 
 extension L10n {
   fileprivate static func tr(_ key: String, _ args: CVarArg...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
+
+private final class BundleToken {}
 
 // swiftlint:enable type_body_length
 // swiftlint:enable nesting

--- a/UnitTests/expected/Strings-File-Dot-Syntax.swift.out
+++ b/UnitTests/expected/Strings-File-Dot-Syntax.swift.out
@@ -78,10 +78,12 @@ enum L10n {
 
 extension L10n {
   private static func tr(key: String, _ args: CVarArgType...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
+
+private final class BundleToken {}
 
 // swiftlint:enable type_body_length
 // swiftlint:enable nesting

--- a/UnitTests/expected/Strings-File-NoComments-Swift3.swift.out
+++ b/UnitTests/expected/Strings-File-NoComments-Swift3.swift.out
@@ -52,7 +52,7 @@ extension L10n: CustomStringConvertible {
   }
 
   private static func tr(key: String, _ args: CVarArg...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
@@ -60,3 +60,5 @@ extension L10n: CustomStringConvertible {
 func tr(_ key: L10n) -> String {
   return key.string
 }
+
+private final class BundleToken {}

--- a/UnitTests/expected/Strings-File-Structured-Only.swift.out
+++ b/UnitTests/expected/Strings-File-Structured-Only.swift.out
@@ -80,7 +80,7 @@ extension L10n: CustomStringConvertible {
   }
 
   private static func tr(key: String, _ args: CVarArgType...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
@@ -91,3 +91,5 @@ extension L10n: CustomStringConvertible {
 func tr(key: L10n) -> String {
   return key.string
 }
+
+private final class BundleToken {}

--- a/UnitTests/expected/Strings-File-Structured.swift.out
+++ b/UnitTests/expected/Strings-File-Structured.swift.out
@@ -152,7 +152,7 @@ extension L10n: CustomStringConvertible {
   }
 
   private static func tr(key: String, _ args: CVarArgType...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
@@ -163,3 +163,5 @@ extension L10n: CustomStringConvertible {
 func tr(key: L10n) -> String {
   return key.string
 }
+
+private final class BundleToken {}

--- a/UnitTests/expected/Strings-File-Swift3.swift.out
+++ b/UnitTests/expected/Strings-File-Swift3.swift.out
@@ -63,7 +63,7 @@ extension L10n: CustomStringConvertible {
   }
 
   private static func tr(key: String, _ args: CVarArg...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
@@ -71,3 +71,5 @@ extension L10n: CustomStringConvertible {
 func tr(_ key: L10n) -> String {
   return key.string
 }
+
+private final class BundleToken {}

--- a/UnitTests/expected/Strings-File-UTF8-Default.swift.out
+++ b/UnitTests/expected/Strings-File-UTF8-Default.swift.out
@@ -59,7 +59,7 @@ extension L10n: CustomStringConvertible {
   }
 
   private static func tr(key: String, _ args: CVarArgType...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
@@ -67,3 +67,5 @@ extension L10n: CustomStringConvertible {
 func tr(key: L10n) -> String {
   return key.string
 }
+
+private final class BundleToken {}

--- a/UnitTests/expected/Strings-Lines-Default.swift.out
+++ b/UnitTests/expected/Strings-Lines-Default.swift.out
@@ -27,7 +27,7 @@ extension L10n: CustomStringConvertible {
   }
 
   private static func tr(key: String, _ args: CVarArgType...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
@@ -35,3 +35,5 @@ extension L10n: CustomStringConvertible {
 func tr(key: L10n) -> String {
   return key.string
 }
+
+private final class BundleToken {}

--- a/UnitTests/expected/Strings-Localizable-Genstrings.swift.out
+++ b/UnitTests/expected/Strings-Localizable-Genstrings.swift.out
@@ -35,37 +35,37 @@ extension L10n: CustomStringConvertible {
   var string: String {
     switch self {
       case .AlertMessage:
-        let format = NSLocalizedString("alert_message", comment: "")
+        let format = NSLocalizedString("alert_message", bundle: stringsBundle, comment: "")
         return L10n.tr(format)
       case .AlertTitle:
-        let format = NSLocalizedString("alert_title", comment: "")
+        let format = NSLocalizedString("alert_title", bundle: stringsBundle, comment: "")
         return L10n.tr(format)
       case .ApplesCount(let p0):
-        let format = NSLocalizedString("apples.count", comment: "")
+        let format = NSLocalizedString("apples.count", bundle: stringsBundle, comment: "")
         return L10n.tr(format, p0)
       case .BananasOwner(let p0, let p1):
-        let format = NSLocalizedString("bananas.owner", comment: "")
+        let format = NSLocalizedString("bananas.owner", bundle: stringsBundle, comment: "")
         return L10n.tr(format, p0, p1)
       case .Greetings(let p0, let p1):
-        let format = NSLocalizedString("greetings", comment: "")
+        let format = NSLocalizedString("greetings", bundle: stringsBundle, comment: "")
         return L10n.tr(format, p0, p1)
       case .ObjectOwnership(let p0, let p1, let p2):
-        let format = NSLocalizedString("ObjectOwnership", comment: "")
+        let format = NSLocalizedString("ObjectOwnership", bundle: stringsBundle, comment: "")
         return L10n.tr(format, p0, p1, p2)
       case .SettingsNavigationBarSelf:
-        let format = NSLocalizedString("settings.navigation-bar.self", comment: "")
+        let format = NSLocalizedString("settings.navigation-bar.self", bundle: stringsBundle, comment: "")
         return L10n.tr(format)
       case .SettingsNavigationBarTitleEvenDeeper:
-        let format = NSLocalizedString("settings.navigation-bar.title.even.deeper", comment: "")
+        let format = NSLocalizedString("settings.navigation-bar.title.even.deeper", bundle: stringsBundle, comment: "")
         return L10n.tr(format)
       case .SettingsNavigationBarTitleEvenDeeperThanWeCanHandle:
-        let format = NSLocalizedString("settings.navigation-bar.title.even.deeper.than.we.can.handle", comment: "")
+        let format = NSLocalizedString("settings.navigation-bar.title.even.deeper.than.we.can.handle", bundle: stringsBundle, comment: "")
         return L10n.tr(format)
       case .SeTTingsUSerProFileSectioNFooterText:
-        let format = NSLocalizedString("seTTings.uSer-proFile-sectioN.footer_text", comment: "")
+        let format = NSLocalizedString("seTTings.uSer-proFile-sectioN.footer_text", bundle: stringsBundle, comment: "")
         return L10n.tr(format)
       case .SettingsUserProfileSectionHeaderTitle:
-        let format = NSLocalizedString("SETTINGS.USER_PROFILE_SECTION.HEADER_TITLE", comment: "")
+        let format = NSLocalizedString("SETTINGS.USER_PROFILE_SECTION.HEADER_TITLE", bundle: stringsBundle, comment: "")
         return L10n.tr(format)
     }
   }
@@ -78,3 +78,6 @@ extension L10n: CustomStringConvertible {
 func tr(key: L10n) -> String {
   return key.string
 }
+
+private final class BundleToken {}
+fileprivate let stringsBundle = Bundle(for: BundleToken.self)

--- a/UnitTests/expected/Strings-Multiline.swift.out
+++ b/UnitTests/expected/Strings-Multiline.swift.out
@@ -39,7 +39,7 @@ extension L10n: CustomStringConvertible {
   }
 
   private static func tr(key: String, _ args: CVarArgType...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
@@ -47,3 +47,5 @@ extension L10n: CustomStringConvertible {
 func tr(key: L10n) -> String {
   return key.string
 }
+
+private final class BundleToken {}

--- a/templates/strings-default.stencil
+++ b/templates/strings-default.stencil
@@ -33,7 +33,7 @@ extension {{enumName}}: CustomStringConvertible {
   }
 
   private static func tr(key: String, _ args: CVarArgType...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
@@ -41,6 +41,9 @@ extension {{enumName}}: CustomStringConvertible {
 func tr(key: {{enumName}}) -> String {
   return key.string
 }
+
+private final class BundleToken {}
+
 {% else %}
 // No string found
 {% endif %}

--- a/templates/strings-dot-syntax-swift3.stencil
+++ b/templates/strings-dot-syntax-swift3.stencil
@@ -40,10 +40,12 @@ enum {{enumName}} {
 
 extension {{enumName}} {
   fileprivate static func tr(_ key: String, _ args: CVarArg...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
+
+private final class BundleToken {}
 
 // swiftlint:enable type_body_length
 // swiftlint:enable nesting

--- a/templates/strings-dot-syntax.stencil
+++ b/templates/strings-dot-syntax.stencil
@@ -38,10 +38,12 @@ enum {{enumName}} {
 
 extension {{enumName}} {
   private static func tr(key: String, _ args: CVarArgType...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
+
+private final class BundleToken {}
 
 // swiftlint:enable type_body_length
 // swiftlint:enable nesting

--- a/templates/strings-genstrings.stencil
+++ b/templates/strings-genstrings.stencil
@@ -20,11 +20,11 @@ extension {{enumName}}: CustomStringConvertible {
       {% for string in strings %}
       {% if string.params %}
       case .{{string.key|swiftIdentifier|snakeToCamelCase}}({{string.params.declarations|join}}):
-        let format = NSLocalizedString("{{string.key}}", comment: "")
+        let format = NSLocalizedString("{{string.key}}", bundle: stringsBundle, comment: "")
         return {{enumName}}.tr(format, {{string.params.names|join}})
       {% else %}
       case .{{string.key|swiftIdentifier|snakeToCamelCase}}:
-        let format = NSLocalizedString("{{string.key}}", comment: "")
+        let format = NSLocalizedString("{{string.key}}", bundle: stringsBundle, comment: "")
         return {{enumName}}.tr(format)
       {% endif %}
       {% endfor %}
@@ -39,6 +39,10 @@ extension {{enumName}}: CustomStringConvertible {
 func tr(key: {{enumName}}) -> String {
   return key.string
 }
+
+private final class BundleToken {}
+fileprivate let stringsBundle = Bundle(for: BundleToken.self)
+
 {% else %}
 // No string found
 {% endif %}

--- a/templates/strings-no-comments-swift3.stencil
+++ b/templates/strings-no-comments-swift3.stencil
@@ -32,7 +32,7 @@ extension {{enumName}}: CustomStringConvertible {
   }
 
   private static func tr(key: String, _ args: CVarArg...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
@@ -40,6 +40,9 @@ extension {{enumName}}: CustomStringConvertible {
 func tr(_ key: {{enumName}}) -> String {
   return key.string
 }
+
+private final class BundleToken {}
+
 {% else %}
 // No string found
 {% endif %}

--- a/templates/strings-structured.stencil
+++ b/templates/strings-structured.stencil
@@ -62,7 +62,7 @@ extension {{enumName}}: CustomStringConvertible {
   }
 
   private static func tr(key: String, _ args: CVarArgType...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
@@ -73,6 +73,9 @@ extension {{enumName}}: CustomStringConvertible {
 func tr(key: {{enumName}}) -> String {
   return key.string
 }
+
+private final class BundleToken {}
+
 {% else %}
 // No string found
 {% endif %}

--- a/templates/strings-swift3.stencil
+++ b/templates/strings-swift3.stencil
@@ -33,7 +33,7 @@ extension {{enumName}}: CustomStringConvertible {
   }
 
   private static func tr(key: String, _ args: CVarArg...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
@@ -41,6 +41,9 @@ extension {{enumName}}: CustomStringConvertible {
 func tr(_ key: {{enumName}}) -> String {
   return key.string
 }
+
+private final class BundleToken {}
+
 {% else %}
 // No string found
 {% endif %}


### PR DESCRIPTION
`NSLocalizedString` defaults to `Bundle.main` when looking up strings.
With this change, we support the following setup:

- `Test.framework`:
    - `Localizable.strings`:
        - `"String" = "Test";`
    - Generated `Strings.swift`.
- App application target.
    - Link against `Test.framework`.
    - Reference `Test.L10n.String.string`.

Without this change, this setup would be looking for the `"String"` string in the main application bundle, which would result in it not being found.

Thanks for submittng a Pull Request to SwiftGen!
Don't forget to add an entry in the `CHANGELOG.md` file to explain your changes and credit yourself!

--- 

## Important: ⚠️ Refactoring in progress ⚠️ 

SwiftGen has arrived to a point where it's big enough to deserve [its own GitHub organization](https://github.com/SwiftGen/), and will also be split into multiple repositories for better structure and flexibility.

This means that SwiftGen's code will be subject to a big reorganizaton (see [#240](https://github.com/AliSoftware/SwiftGen/issues/240)) and that it may not be the best time to submit a new PR, as it will likely not be valid anymore after that refactoring.

We still welcome new PRs very much of course, and are really glad you wish to contribute! But if your change is likely to be affected by this big reorganization, it might be easier for you to wait a few weeks until that refactoring is finished (It's not expected to last long — we hope to finish that big migration ASAP) before submitting your changes, to avoid doing the work twice.

---
